### PR TITLE
Add basic Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - jruby-18mode
+  - jruby-19mode
+  - jruby-head
+script: bundle exec shindont


### PR DESCRIPTION
This adds a basic config for Travis.

It currently errors https://travis-ci.org/tokengeek/fog-core/builds/18612223 because of `mime-types` requiring Ruby 1.9.3 or greater.

I'm not sure if we want to keep up with the two Gemfile approach on core or not.
