### PR TITLE
Prepare version to be v1.21.0

### DIFF
--- a/lib/fog/version.rb
+++ b/lib/fog/version.rb
@@ -1,3 +1,3 @@
 module Fog
-  VERSION = "1.20.0"
+  VERSION = "1.21.0"
 end


### PR DESCRIPTION
Since `fog-core` versions will predate `fog` versions and the next
version would be v1.21.0 so this allows us to reference the correct core
