### PR TITLE
"require" accidentally removed during fog-core extraction

### DIFF
--- a/lib/fog/core/provider.rb
+++ b/lib/fog/core/provider.rb
@@ -19,11 +19,12 @@ module Fog
       eval(@services_registry[service_key]).new
     end
 
-    def service(new_service, constant_string)
+    def service(new_service, path, constant_string)
       Fog.services[new_service] ||= []
       Fog.services[new_service] |= [self.to_s.split('::').last.downcase.to_sym]
       @services_registry ||= {}
       @services_registry[new_service] = [self.to_s, constant_string].join('::')
+      require File.join('fog', path)
     end
 
     def services


### PR DESCRIPTION
This issue prevents providers from being loaded in total.  Pretty important to fix this....
