### PR TITLE
Let the wait_for method accept a callback to support variable interval

### DIFF
--- a/lib/fog/core/errors.rb
+++ b/lib/fog/core/errors.rb
@@ -19,6 +19,7 @@ module Fog
     class LoadError < LoadError; end
 
     class TimeoutError< Fog::Errors::Error; end
+    class RetryTimesExceeded< Fog::Errors::Error; end
 
     class NotImplemented < Fog::Errors::Error; end
 

--- a/lib/fog/core/model.rb
+++ b/lib/fog/core/model.rb
@@ -59,9 +59,12 @@ module Fog
       end
     end
 
-    def wait_for(timeout=Fog.timeout, interval=1, &block)
+    def wait_for(options = {}, *bc_params, &block)
       reload_has_succeeded = false
-      duration = Fog.wait_for(timeout, interval) do # Note that duration = false if it times out
+
+      options = Fog.wait_for_bc_options(options, *bc_params)
+      
+      duration = Fog.wait_for(options) do # Note that duration = false if it times out
         if reload
           reload_has_succeeded = true
           instance_eval(&block)

--- a/lib/fog/core/wait_for.rb
+++ b/lib/fog/core/wait_for.rb
@@ -1,17 +1,53 @@
 module Fog
-  def self.wait_for(timeout=Fog.timeout, sleeper=Fog.interval, &block)
+  # Wait for something to change to the specified status.
+  #
+  # @param [Hash] options
+  #
+  # @option options [Integer] :timeout  Maximum seconds to wait for the status change.
+  # @option options [Proc]    :wait_policy  A proc that returns an integer. 
+  #   The returned value will be used as the parameter of the 'sleep' call.
+  # @option options [Array]   :ignored_errors Ignore errors within this array and resume the retry.
+  # @option options [Integer] :max_retries  Maximum times to retry. 
+  #   Stop retry  ether when times exceeded or timeout occurred.
+  def self.wait_for(options={}, *bc_params, &block)
     duration = 0
-    start = Time.now
-    times = 0
-    until yield || duration > timeout
-      interval = sleeper.respond_to?(:call) ? sleeper.call(times += 1) : sleeper
-      sleep(interval.to_f)
-      duration = Time.now - start
+    retries = 0
+
+    options = Fog.wait_for_bc_options(options, *bc_params)
+    max_retries = options[:max_retries] || 65535
+    ignored_errors = options[:ignored_errors] || []
+    wait_policy = options[:wait_policy] || Fog.interval
+    timeout = options[:timeout] || Fog.timeout
+
+    begin
+      loop do
+        raise Errors::TimeoutError, "The specified wait_for timeout (#{timeout} seconds) was exceeded" if duration >= timeout
+        raise Errors::RetryTimesExceeded, "The specified :max_retries (#{max_retries}) was exceeded" if retries > max_retries
+        return { :duration => duration } if yield
+        duration += Fog.wait(retries += 1, wait_policy)
+      end
+    rescue *ignored_errors => e
+      raise Errors::RetryTimesExceeded, "The specified :max_retries (#{max_retries}) was exceeded" if retries > max_retries
+      duration += Fog.wait(retries += 1, wait_policy)
+      retry
     end
-    if duration > timeout
-      raise Errors::TimeoutError.new("The specified wait_for timeout (#{timeout} seconds) was exceeded")
-    else
-      { :duration => duration }
+  end
+
+  def self.wait(retries, policy)
+    interval = policy.respond_to?(:call) ? policy.call(retries) : policy
+    sleep(interval.to_f)
+  end
+
+  def self.wait_for_bc_options(options = {}, *bc_params)
+    # For BC purpose. 
+    unless options.kind_of?(Hash)
+      Fog::Logger.deprecation "Calling Fog.wait_for with interger params is deprecated. "\
+        "Please call it this way: Fog.wait_for(:timeout => 3, :wait_policy => proc or interval, :max_retries => 2, :ignored_errors => [some errors])"
+      options = {
+        :timeout => options, 
+        :wait_policy => bc_params.first
+      }
     end
+    options
   end
 end

--- a/lib/tasks/test_task.rb
+++ b/lib/tasks/test_task.rb
@@ -1,5 +1,6 @@
 require "rake"
 require "rake/tasklib"
+require "fog/core"
 
 module Fog
   module Rake

--- a/tests/core/wait_for_tests.rb
+++ b/tests/core/wait_for_tests.rb
@@ -1,18 +1,28 @@
 Shindo.tests('Fog#wait_for', 'core') do
   tests("success") do
-    tests('Fog#wait_for').formats(:duration => Integer) do
+    tests('Fog#wait_for BC').formats(:duration => Integer) do
       Fog.wait_for(1) { true }
     end
 
-    tests('Fog#wait_for with callback').formats(:duration => Integer) do
-      callback = lambda { |times| times * 0.01 }
-      Fog.wait_for(5, callback) { true }
+    tests("Fog#wait_for with :wait_policy").formats(:duration => Integer) do
+      wait_policy = lambda { |times| times * 0.01 }
+      Fog.wait_for(:wait_policy => wait_policy) { true }
     end
   end
   
   tests("failure") do
     tests('Fog#wait_for').raises(Fog::Errors::TimeoutError) do
       Fog.wait_for(2) { false }
+    end
+
+    tests("Fog#wait_for with :timeout").raises(Fog::Errors::TimeoutError) do
+      i = 0
+      Fog.wait_for(:timeout => 1) { i += 1; i > 2 }
+    end
+
+    tests("Fog#wait_for with :max_retries").raises(Fog::Errors::RetryTimesExceeded) do
+      i = 0
+      Fog.wait_for(:max_retries => 1) { i += 1; i > 2 }
     end
   end
 end


### PR DESCRIPTION
Use case: http://docs.aws.amazon.com/general/latest/gr/api-retries.html
