### PR TITLE
Refactor with an eye toward separation of git-core and specific provider

### DIFF
--- a/lib/fog/identity.rb
+++ b/lib/fog/identity.rb
@@ -13,7 +13,6 @@ module Fog
         Fog::Rackspace::Identity.new(attributes)
       else
         if self.providers.include?(provider)
-          # require "fog/#{provider}/identity"
           return Fog::Identity.const_get(Fog.providers[provider]).new(attributes)
         end
         raise ArgumentError.new("#{provider} has no identity service")


### PR DESCRIPTION
I'm currently working on the rewrite of the OpenStack provider in a separate gem. As a result, the 'require' for the provider needs to occur within the context of the new gem, not fog-core. 
