### PR TITLE
Clone init attributes to prevent side effects

### DIFF
--- a/lib/fog/core/model.rb
+++ b/lib/fog/core/model.rb
@@ -12,12 +12,13 @@ module Fog
 
     def initialize(new_attributes = {})
       # TODO Remove compatibility with old connection option
-      @service = new_attributes.delete(:service)
-      if @service.nil? && new_attributes[:connection]
+      attribs = new_attributes.clone
+      @service = attribs.delete(:service)
+      if @service.nil? && attribs[:connection]
         Fog::Logger.deprecation("Passing :connection option is deprecated, use :service instead [light_black](#{caller.first})[/]")
-        @service = new_attributes[:connection]
+        @service = attribs[:connection]
       end
-      merge_attributes(new_attributes)
+      merge_attributes(attribs)
     end
 
     def inspect


### PR DESCRIPTION
In the new openstack provider, we are seeing side effects in specs/tests when we new up more than one model object (User, Tenant, Role) with a given spec/test. We tracked it back to the way that the fog model.rb is handling the `new_attributes`` options hash. It's mutating the hash as it comes in while newing up the first object, which affects the second and third objects being created. We worked around it by not using the options hash more than once, but this still should be addressed. 

Hopefully this PR will fix this.
