### PR TITLE
Lock rake to 10.1 for Ruby 1.8.7

### DIFF
--- a/Gemfile.1.8.7
+++ b/Gemfile.1.8.7
@@ -4,6 +4,7 @@ gem 'nokogiri', '~>1.5.11'
 gem 'mime-types', '~>1.16'
 
 group :development, :test do
+  gem 'rake', '~> 10.1.0'
   # This is here because gemspec doesn't support require: false
   gem 'coveralls', :require => false
 end


### PR DESCRIPTION
Rake has gone 1.9.3+ from 10.2 onwards so the Gemfile for 1.8.7
specifies this new constraint.
