### PR TITLE
Allow for `Fog::<provider>::Storage` as well as `Fog::Storage::<provider>`

### DIFF
--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -19,10 +19,14 @@ module Fog
       else
         if self.providers.include?(provider)
           require "fog/#{provider}/storage"
-          return Fog::Storage.const_get(Fog.providers[provider]).new(attributes)
+          begin
+            Fog::Storage.const_get(Fog.providers[provider])
+          rescue
+            Fog::const_get(Fog.providers[provider])::Storage
+          end.new(attributes)
+        else
+          raise ArgumentError.new("#{provider} is not a recognized storage provider")
         end
-
-        raise ArgumentError.new("#{provider} is not a recognized storage provider")
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'minitest/stub_const'
+
+$LOAD_PATH.unshift "lib"
+
 require 'fog/core'
 

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+
+module Fog
+  module Storage
+    def self.require(*args); end
+  end
+end
+
+describe "Fog::Storage" do
+  describe "#new" do
+    module Fog
+      module TheRightWay
+        extend Provider
+        service(:storage, 'Storage')
+      end
+    end
+
+    module Fog
+      module Storage
+        class TheRightWay
+          def initialize(args); end
+        end
+      end
+    end
+
+    it "instantiates an instance of Fog::Storage::<Provider> from the :provider keyword arg" do
+      compute = Fog::Storage.new(:provider => :therightway)
+      assert_instance_of(Fog::Storage::TheRightWay, compute)
+    end
+
+
+    module Fog
+      module TheWrongWay
+        extend Provider
+        service(:storage, 'Storage')
+      end
+    end
+
+    module Fog
+      module TheWrongWay
+        class Storage
+          def initialize(args); end
+        end
+      end
+    end
+
+    it "instantiates an instance of Fog::<Provider>::Storage from the :provider keyword arg" do
+      compute = Fog::Storage.new(:provider => :thewrongway)
+      assert_instance_of(Fog::TheWrongWay::Storage, compute)
+    end
+
+    module Fog
+      module BothWays
+        extend Provider
+        service(:storage, 'Storage')
+      end
+    end
+
+    module Fog
+      module BothWays
+        class Storage
+          def initialize(args); end
+        end
+      end
+    end
+
+    module Fog
+      module Storage
+        class BothWays
+          attr_reader :args
+          def initialize(args)
+            @args = args
+          end
+        end
+      end
+    end
+
+    describe "when both Fog::Storage::<Provider> and Fog::<Provider>::Storage exist" do
+      it "prefers Fog::Storage::<Provider>" do
+        compute = Fog::Storage.new(:provider => :bothways)
+        assert_instance_of(Fog::Storage::BothWays, compute)
+      end
+    end
+    
+    it "passes the supplied keyword args less :provider to Fog::Storage::<Provider>#new" do
+      compute = Fog::Storage.new(:provider => :bothways, :extra => :stuff)
+      assert_equal({:extra => :stuff}, compute.args)
+    end
+
+    it "raises ArgumentError when given a :provider where a Fog::Storage::Provider that does not exist" do
+      assert_raises(ArgumentError) do
+        Fog::Storage.new(:provider => :wat)
+      end
+    end    
+  end
+end


### PR DESCRIPTION
Generic solution so as to avoid more hard-coding in compute.rb.

Includes spec based on identity_spec.rb though repurposed for Storage.

For 2.0, the `Fog::<provider>::<service>`/`Fog::<service>::<provider>`
should be replaced with more explicit names.  Perhaps
`Fog::Builtins::<provider>::<service>` and
`Fog::Extensions::<provider>::<service>` or similar.

TL;DR: I'd rather have another layer of modules, containing an intent-
revealing name than a conventon where `Fog::<provider>::<service>`
implies
one thing and `Fog::<service>::<provider>` implies another.

For #37.
