### PR TITLE
Whitelisting of params

### DIFF
--- a/lib/fog/core.rb
+++ b/lib/fog/core.rb
@@ -32,8 +32,8 @@ require 'fog/core/wait_for'
 require 'fog/core/wait_for_defaults'
 require 'fog/core/class_from_string'
 require 'fog/core/uuid'
-require 'fog/core/stringify'
-require 'fog/core/whitelist'
+require 'fog/core/stringify_keys'
+require 'fog/core/whitelist_keys'
 
 # service wrappers
 require 'fog/compute'

--- a/lib/fog/core/stringify_keys.rb
+++ b/lib/fog/core/stringify_keys.rb
@@ -1,8 +1,8 @@
 module Fog
-  module Stringify
+  module StringifyKeys
 
     # Returns a new hash with all keys converted to strings.
-    def self.keys(hash)
+    def self.stringify(hash)
       self.transform_hash(hash) {|hash, key, value|
         hash[key.to_s] = value
       }

--- a/lib/fog/core/whitelist.rb
+++ b/lib/fog/core/whitelist.rb
@@ -1,8 +1,0 @@
-module Fog
-  module Whitelist
-    def self.whitelist_keys(hash, valid_keys)
-      valid_hash = Stringify.keys(hash)
-      valid_hash.select {|k,v| valid_keys.include?(k)}
-    end
-  end
-end

--- a/lib/fog/core/whitelist_keys.rb
+++ b/lib/fog/core/whitelist_keys.rb
@@ -1,0 +1,8 @@
+module Fog
+  module WhitelistKeys
+    def self.whitelist(hash, valid_keys)
+      valid_hash = StringifyKeys.stringify(hash)
+      valid_hash.select {|k,v| valid_keys.include?(k)}
+    end
+  end
+end

--- a/tests/core/stringify_keys_tests.rb
+++ b/tests/core/stringify_keys_tests.rb
@@ -8,19 +8,19 @@ output_hash = {
   'flavor' => '123'
 }
 
-Shindo.tests('Fog::Stringify', 'core') do
+Shindo.tests('Fog::StringifyKeys', 'core') do
 
   tests('keys') do
 
     tests('stringifies symbols') do
       returns(output_hash) {
-        Fog::Stringify.keys(input_hash)
+        Fog::StringifyKeys.stringify(input_hash)
       }
     end
 
     tests('skips strings') do
       returns(output_hash) {
-        Fog::Stringify.keys(output_hash)
+        Fog::StringifyKeys.stringify(output_hash)
       }
     end
 

--- a/tests/core/whitelist_keys_tests.rb
+++ b/tests/core/whitelist_keys_tests.rb
@@ -11,12 +11,12 @@ output_hash = {
 
 valid_keys = %w{flavor name}
 
-Shindo.tests('Fog::Whitelist', 'core') do
+Shindo.tests('Fog::WhitelistKeys', 'core') do
 
   tests('whitelist_keys') do
     tests('excludes invalid values') do
       returns(output_hash) {
-        Fog::Whitelist.whitelist_keys(input_hash, valid_keys)
+        Fog::WhitelistKeys.whitelist(input_hash, valid_keys)
       }
     end
   end


### PR DESCRIPTION
We have a need to whitelist params being passed into a method in the openstack-core provider, and thought this might be more broadly applicable to fog. 
