### PR TITLE
Rescuing from File not found exception

### DIFF
--- a/lib/fog/compute.rb
+++ b/lib/fog/compute.rb
@@ -54,7 +54,7 @@ module Fog
         Fog::Compute::VcloudDirector.new(attributes)
       else
         if self.providers.include?(provider)
-          require "fog/#{provider}/compute" rescue nil
+          require "fog/#{provider}/compute" rescue LoadError; nil
           begin
             Fog::Compute.const_get(Fog.providers[provider])
           rescue


### PR DESCRIPTION
There are some cases, like in [fog-xenserver](https://github.com/fog/fog-xenserver) that there is no compute file inside the provider folder.
In this particular case, when loading `fog/xenserver` it will automatically loading all files making this `require` unecessary.

As discussed in fog/fog-xenserver#1 we are defining the `Xenserver` Service class inside the `Compute` namespace, which makes the path to require a little bit different. It would have to be:

``` ruby
require "fog/compute/#{provider}"
```

but to keep the compatibility with the others services we can let it this way, and just rescue when not found since [fog-xenserver](https://github.com/fog/fog-xenserver) already load's everything. :smile: 
