### PR TITLE
allow namespace variations for dns like compute

### DIFF
--- a/lib/fog/dns.rb
+++ b/lib/fog/dns.rb
@@ -14,10 +14,14 @@ module Fog
       else
         if self.providers.include?(provider)
           require "fog/#{provider}/dns"
-          return Fog::DNS.const_get(Fog.providers[provider]).new(attributes)
+          begin
+            Fog::DNS.const_get(Fog.providers[provider])
+          rescue
+            Fog::const_get(Fog.providers[provider])::DNS
+          end.new(attributes)
+        else
+          raise ArgumentError.new("#{provider} is not a recognized dns provider")
         end
-
-        raise ArgumentError.new("#{provider} is not a recognized dns provider")
       end
     end
 


### PR DESCRIPTION
this allows both Fog::HP::DNS and Fog::DNS::HP to be valid services just like the change made for compute.
