### PR TITLE
Fixed default value on a new object with a custom value

### DIFF
--- a/lib/fog/core/attributes/default.rb
+++ b/lib/fog/core/attributes/default.rb
@@ -43,6 +43,7 @@ module Fog
       def create_getter
         model.class_eval <<-EOS, __FILE__, __LINE__
           def #{name}
+            return attributes[:#{name}] unless attributes[:#{name}].nil?
             if !self.class.default_values[:#{name}].nil? && !persisted?
               return self.class.default_values[:#{name}]
             end

--- a/spec/fog_attribute_spec.rb
+++ b/spec/fog_attribute_spec.rb
@@ -169,8 +169,13 @@ describe "Fog::Attributes" do
       assert_equal model.bool, false
     end
 
-    it "should return the default value on a new object" do
+    it "should return the default value on a new object with value equal nil" do
       assert_equal model.default, 'default_value'
+    end
+
+    it "should return the value on a new object with value not equal nil" do
+      model.default = 'not default'
+      assert_equal model.default, 'not default'
     end
 
     it "should return false when default value is false on a new object" do


### PR DESCRIPTION
It was always returning the default value when not persisted.

Regression test added to ensure it doesn't happen again.
