### PR TITLE
Added possibility to pass objects when working with Identity Associations

### DIFF
--- a/lib/fog/core/associations/many_identities.rb
+++ b/lib/fog/core/associations/many_identities.rb
@@ -4,7 +4,9 @@ module Fog
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__
           def #{name}=(new_#{name})
-            associations[:#{name}] = Array(new_#{name})
+            associations[:#{name}] = Array(new_#{name}).map do |association|
+                                       association.respond_to?(:identity) ? association.identity : association
+                                     end
           end
         EOS
       end

--- a/lib/fog/core/associations/one_identity.rb
+++ b/lib/fog/core/associations/one_identity.rb
@@ -4,7 +4,7 @@ module Fog
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__
           def #{name}=(new_#{name})
-            associations[:#{name}] = new_#{name}
+            associations[:#{name}] = new_#{name}.respond_to?(:identity) ? new_#{name}.identity : new_#{name}
           end
         EOS
       end

--- a/spec/fog_attribute_spec.rb
+++ b/spec/fog_attribute_spec.rb
@@ -276,9 +276,16 @@ describe "Fog::Attributes" do
       assert_equal model.one_identity.attributes, { :id => '123' }
     end
 
-    it "should create a setter that accept an id as param" do
-      model.one_identity = '123'
-      assert_equal model.one_identity.attributes, { :id => '123' }
+    describe "should create a setter that accept" do
+      it "an id as param" do
+        model.one_identity = '123'
+        assert_equal model.one_identity.attributes, { :id => '123' }
+      end
+
+      it "a model as param" do
+        model.one_identity = FogSingleAssociationModel.new(:id => '123')
+        assert_equal model.one_identity.attributes, { :id => '123' }
+      end
     end
   end
 
@@ -314,9 +321,16 @@ describe "Fog::Attributes" do
       assert_equal model.many_identities.first.attributes, { :id => '456' }
     end
 
-    it "should create a setter that accept an array of ids as param" do
-      model.many_identities = [ '456' ]
-      assert_equal model.many_identities.first.attributes, { :id => '456' }
+    describe "should create a setter that accept an array of" do
+      it "ids as param" do
+        model.many_identities = [ '456' ]
+        assert_equal model.many_identities.first.attributes, { :id => '456' }
+      end
+
+      it "models as param" do
+        model.many_identities = [ FogMultipleAssociationsModel.new(:id => '456') ]
+        assert_equal model.many_identities.first.attributes, { :id => '456' }
+      end
     end
   end
 


### PR DESCRIPTION
@geemus What do you think of this? It would make easier to work with providers that does not return models, by accepting both the identity and the object when setting the value like:

``` ruby
@model = MyModel.new
@association = @conn.associations.get('some-id')
@model.association = @association
# or
@model.association = @association.identity
```
