### PR TITLE
Use define_method to support aliases with dashes.

### DIFF
--- a/lib/fog/core/attributes/default.rb
+++ b/lib/fog/core/attributes/default.rb
@@ -58,11 +58,11 @@ module Fog
         Array(aliases).each do |alias_name|
           model.aliases[alias_name] = name
           model.class_eval <<-EOS, __FILE__, __LINE__
-            def #{alias_name}=(new_data)
+            define_method(:'#{alias_name}=') do |new_data|
               name = new_data
             end
 
-            def #{alias_name}
+            define_method(:'#{alias_name}') do
               name
             end
           EOS


### PR DESCRIPTION
[This change](https://github.com/fog/fog-core/blob/68524a22fde9fed70e61534532f3679d26ee451c/lib/fog/core/attributes/default.rb#L57-L70) that was added about an hour ago in 68524a22fde9fed70e61534532f3679d26ee451c breaks the `Storage` service in `fog-softlayer` which using HTTP headers (Content-Type, Content-Length, etc) as aliases.

This PR fixes that.
