### PR TITLE
Last touching on #all_attributes

### DIFF
--- a/lib/fog/core/attributes.rb
+++ b/lib/fog/core/attributes.rb
@@ -73,11 +73,10 @@ module Fog
       end
 
       def all_attributes
-        all_attributes = self.class.attributes.inject({}) do |hash, attribute|
+        self.class.attributes.inject({}) do |hash, attribute|
           hash[attribute] = send(attribute)
           hash
         end
-        self.class.new(all_attributes).attributes
       end
 
       def dup

--- a/spec/fog_attribute_spec.rb
+++ b/spec/fog_attribute_spec.rb
@@ -343,14 +343,15 @@ describe "Fog::Attributes" do
     describe "on a persisted object" do
       it "should return all attributes without default values" do
         model.merge_attributes( :id => 2, :float => 3.2, :integer => 55555555 )
+        assert model.persisted?
         assert_equal model.all_attributes, { :id => 2,
                                              :key => nil,
                                              :time => nil,
                                              :bool => nil,
                                              :float => 3.2,
                                              :integer => 55555555,
-                                             :string => '',
-                                             :timestamp => Time.at(0),
+                                             :string => nil,
+                                             :timestamp => nil,
                                              :array => [],
                                              :default => nil,
                                              :another_default => nil }
@@ -359,15 +360,16 @@ describe "Fog::Attributes" do
 
     describe "on a new object" do
       it "should return all attributes including default values for empty attributes" do
-        model.merge_attributes( :id => nil, :float => 3.2, :integer => 55555555 )
+        model.merge_attributes( :float => 3.2, :integer => 55555555 )
+        refute model.persisted?
         assert_equal model.all_attributes, { :id => nil,
                                              :key => nil,
                                              :time => nil,
                                              :bool => nil,
                                              :float => 3.2,
                                              :integer => 55555555,
-                                             :string => '',
-                                             :timestamp => Time.at(0),
+                                             :string => nil,
+                                             :timestamp => nil,
                                              :array => [],
                                              :default => 'default_value',
                                              :another_default => false }


### PR DESCRIPTION
It is now well defined and covered by tests. The behavior expected is to
not return any default value on persisted objects and return the default
values on non persisted objects in attributes not defined.

The method #all_attributes were initializing a new objet with the has of
attributes from the actual object to get the final hash of attributes,
but this were leading to the wrong behavior (not the expected).

@geemus. The method #all_attributes is now working as expected. I tested it against `fog-xenserver` locally and ll went fine.
