### PR TITLE
Remove gem update from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,3 @@ notifications:
     on_success: always
     on_failure: always
     use_notice: false
-
-before_install:
-  - gem update --system #  todo: workaround for https://github.com/rubygems/rubygems/pull/763


### PR DESCRIPTION
This code was being executed to fix an issue related to rubygems
(https://github.com/rubygems/rubygems/pull/763).
This was fixed and merged 8 months ago and this code is breaking some
build on Travis because of timeouts.
