### PR TITLE
Added feature to overwrite keys on hash of attributes generation

### DIFF
--- a/lib/fog/core/associations/default.rb
+++ b/lib/fog/core/associations/default.rb
@@ -1,22 +1,28 @@
 module Fog
   module Associations
     class Default
-      attr_reader :model, :name, :aliases
+      attr_reader :model, :name, :aliases, :as
 
       def initialize(model, name, collection_name, options)
         @model = model
         @name = name
         model.associations[name] = collection_name
         @aliases = options.fetch(:aliases, [])
+        @as = options.fetch(:as, name)
         create_setter
         create_getter
         create_aliases
+        create_mask
       end
 
       def create_aliases
         Array(aliases).each do |alias_name|
           model.aliases[alias_name] = name
         end
+      end
+
+      def create_mask
+        model.masks[name] = as
       end
     end
   end

--- a/lib/fog/core/attributes.rb
+++ b/lib/fog/core/attributes.rb
@@ -22,6 +22,10 @@ module Fog
         @default_values ||= {}
       end
 
+      def masks
+        @masks ||= {}
+      end
+
       def attribute(name, options = {})
         type = options.fetch(:type, 'default').to_s.capitalize
         Fog::Attributes::const_get(type).new(self, name, options)
@@ -72,16 +76,20 @@ module Fog
         @associations ||= {}
       end
 
+      def masks
+        self.class.masks
+      end
+
       def all_attributes
         self.class.attributes.inject({}) do |hash, attribute|
-          hash[attribute] = send(attribute)
+          hash[masks[attribute]] = send(attribute)
           hash
         end
       end
 
       def all_associations
         self.class.associations.keys.inject({}) do |hash, association|
-          hash[association] = associations[association] || send(association)
+          hash[masks[association]] = associations[association] || send(association)
           hash
         end
       end

--- a/lib/fog/core/attributes/default.rb
+++ b/lib/fog/core/attributes/default.rb
@@ -1,7 +1,7 @@
 module Fog
   module Attributes
     class Default
-      attr_reader :model, :name, :squash, :aliases, :default
+      attr_reader :model, :name, :squash, :aliases, :default, :as
 
       def initialize(model, name, options)
         @model = model
@@ -10,10 +10,12 @@ module Fog
         @squash = options.fetch(:squash, false)
         @aliases = options.fetch(:aliases, [])
         @default = options[:default]
+        @as = options.fetch(:as, name)
         create_setter
         create_getter
         create_aliases
         set_defaults
+        create_mask
       end
 
       def create_setter
@@ -62,6 +64,10 @@ module Fog
 
       def set_defaults
         model.default_values[name] = default unless default.nil?
+      end
+
+      def create_mask
+        model.masks[name] = as
       end
     end
   end

--- a/spec/fog_attribute_spec.rb
+++ b/spec/fog_attribute_spec.rb
@@ -13,10 +13,11 @@ class FogAttributeTestModel < Fog::Model
   attribute :array, :type => :array
   attribute :default, :default => 'default_value', :aliases => :some_name
   attribute :another_default, :default => false
+  attribute :good_name, :as => :Badname
 
   has_one :one_object, :single_associations, :aliases => :single
   has_many :many_objects, :multiple_associations
-  has_one_identity :one_identity, :single_associations
+  has_one_identity :one_identity, :single_associations, :as => :Crazyname
   has_many_identities :many_identities, :multiple_associations, :aliases => :multiple
 
   def service
@@ -364,7 +365,8 @@ describe "Fog::Attributes" do
                                              :timestamp => nil,
                                              :array => [],
                                              :default => nil,
-                                             :another_default => nil }
+                                             :another_default => nil,
+                                             :Badname => nil }
       end
     end
 
@@ -382,7 +384,8 @@ describe "Fog::Attributes" do
                                              :timestamp => nil,
                                              :array => [],
                                              :default => 'default_value',
-                                             :another_default => false }
+                                             :another_default => false,
+                                             :Badname => nil }
       end
     end
   end
@@ -392,7 +395,7 @@ describe "Fog::Attributes" do
       it "should return all associations empty" do
         assert_equal model.all_associations, { :one_object => nil,
                                                :many_objects => [],
-                                               :one_identity => nil,
+                                               :Crazyname => nil,
                                                :many_identities => [] }
       end
     end
@@ -405,7 +408,7 @@ describe "Fog::Attributes" do
         model.merge_attributes(:one_identity => 'XYZ', :many_identities => %w(ABC))
         assert_equal model.all_associations, { :one_object => @one_object,
                                                :many_objects => @many_objects,
-                                               :one_identity => 'XYZ',
+                                               :Crazyname => 'XYZ',
                                                :many_identities => %w(ABC) }
       end
     end
@@ -431,9 +434,10 @@ describe "Fog::Attributes" do
                                          :array => [],
                                          :default => nil,
                                          :another_default => nil,
+                                         :Badname => nil,
                                          :one_object => @one_object,
                                          :many_objects => @many_objects,
-                                         :one_identity => 'XYZ',
+                                         :Crazyname => 'XYZ',
                                          :many_identities => %w(ABC) }
       end
     end
@@ -457,9 +461,10 @@ describe "Fog::Attributes" do
                                          :array => [],
                                          :default => 'default_value',
                                          :another_default => false,
+                                         :Badname => nil,
                                          :one_object => @one_object,
                                          :many_objects => @many_objects,
-                                         :one_identity => 'XYZ',
+                                         :Crazyname => 'XYZ',
                                          :many_identities => %w(ABC) }
       end
     end


### PR DESCRIPTION
Fog already has support to inform that an attribute might be
initialized with another name. This feature makes possible to map
attributes that aren't ruby friend to friendly ones.

This code makes possible to map the attributes that are ruby friendly
to the methods that the provider need/wants.

Together, the `aliases` and `as` options will map the inialization
of the attributes and the generation of proper attribute names.
