### PR TITLE
Removed #method_missing from Fog::Model

### DIFF
--- a/lib/fog/core/model.rb
+++ b/lib/fog/core/model.rb
@@ -76,17 +76,5 @@ module Fog
         raise Fog::Errors::Error.new("Reload failed, #{self.class} #{self.identity} not present.")
       end
     end
-
-    def method_missing(method_name, *args)
-      if self.class.aliases.include?(method_name)
-        send(self.class.aliases[method_name])
-      else
-        super
-      end
-    end
-
-    def respond_to?(method_name, include_private = false)
-      super || self.class.aliases.include?(method_name)
-    end
   end
 end

--- a/spec/fog_attribute_spec.rb
+++ b/spec/fog_attribute_spec.rb
@@ -469,12 +469,4 @@ describe "Fog::Attributes" do
       end
     end
   end
-
-  describe "aliases accessors" do
-    it "should have accessors to the original attribute" do
-      model.merge_attributes(:default => true)
-      assert model.respond_to?(:some_name)
-      assert model.some_name
-    end
-  end
 end


### PR DESCRIPTION
Since #74 is merged, we dont need to create acessors to the aliases anymore.
