### PR TITLE
More Rubocop warnings fixes

### DIFF
--- a/lib/fog/test_helpers/compute/flavors_helper.rb
+++ b/lib/fog/test_helpers/compute/flavors_helper.rb
@@ -1,8 +1,6 @@
-def flavors_tests(connection, params = {}, mocks_implemented = true)
-
+def flavors_tests(connection, _params = {}, mocks_implemented = true)
   tests('success') do
-
-    tests("#all").succeeds do
+    tests('#all').succeeds do
       pending if Fog.mocking? && !mocks_implemented
       connection.flavors.all
     end
@@ -15,11 +13,9 @@ def flavors_tests(connection, params = {}, mocks_implemented = true)
       pending if Fog.mocking? && !mocks_implemented
       connection.flavors.get(@identity)
     end
-
   end
 
   tests('failure') do
-
     if !Fog.mocking? || mocks_implemented
       invalid_flavor_identity = connection.flavors.first.identity.to_s.gsub(/\w/, '0')
     end
@@ -28,7 +24,5 @@ def flavors_tests(connection, params = {}, mocks_implemented = true)
       pending if Fog.mocking? && !mocks_implemented
       connection.flavors.get(invalid_flavor_identity)
     end
-
   end
-
 end

--- a/lib/fog/test_helpers/compute/server_helper.rb
+++ b/lib/fog/test_helpers/compute/server_helper.rb
@@ -1,7 +1,5 @@
 def server_tests(connection, params = {}, mocks_implemented = true)
-
   model_tests(connection.servers, params, mocks_implemented) do
-
     tests('#reload').returns(true) do
       pending if Fog.mocking? && !mocks_implemented
       @instance.wait_for { ready? }
@@ -18,10 +16,6 @@ def server_tests(connection, params = {}, mocks_implemented = true)
       @instance.reboot
     end
 
-    if !Fog.mocking? || mocks_implemented
-      @instance.wait_for { ready? }
-    end
-
+    @instance.wait_for { ready? } if !Fog.mocking? || mocks_implemented
   end
-
 end

--- a/lib/fog/test_helpers/compute/servers_helper.rb
+++ b/lib/fog/test_helpers/compute/servers_helper.rb
@@ -1,12 +1,8 @@
 def servers_tests(connection, params = {}, mocks_implemented = true)
-
   collection_tests(connection.servers, params, mocks_implemented) do
-
     if !Fog.mocking? || mocks_implemented
       @instance.wait_for { ready? }
       yield if block_given?
     end
-
   end
-
 end

--- a/lib/fog/test_helpers/formats_helper.rb
+++ b/lib/fog/test_helpers/formats_helper.rb
@@ -1,4 +1,4 @@
-require "fog/schema/data_validator"
+require 'fog/schema/data_validator'
 
 # format related hackery
 # allows both true.is_a?(Fog::Boolean) and false.is_a?(Fog::Boolean)
@@ -15,18 +15,17 @@ module Fog
     module Array; end
   end
 end
-[FalseClass, TrueClass].each {|klass| klass.send(:include, Fog::Boolean)}
-[FalseClass, TrueClass, NilClass, Fog::Boolean].each {|klass| klass.send(:include, Fog::Nullable::Boolean)}
-[NilClass, String].each {|klass| klass.send(:include, Fog::Nullable::String)}
-[NilClass, Time].each {|klass| klass.send(:include, Fog::Nullable::Time)}
-[Integer, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Integer)}
-[Float, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Float)}
-[Hash, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Hash)}
-[Array, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Array)}
+[FalseClass, TrueClass].each { |klass| klass.send(:include, Fog::Boolean) }
+[FalseClass, TrueClass, NilClass, Fog::Boolean].each { |klass| klass.send(:include, Fog::Nullable::Boolean) }
+[NilClass, String].each { |klass| klass.send(:include, Fog::Nullable::String) }
+[NilClass, Time].each { |klass| klass.send(:include, Fog::Nullable::Time) }
+[Integer, NilClass].each { |klass| klass.send(:include, Fog::Nullable::Integer) }
+[Float, NilClass].each { |klass| klass.send(:include, Fog::Nullable::Float) }
+[Hash, NilClass].each { |klass| klass.send(:include, Fog::Nullable::Hash) }
+[Array, NilClass].each { |klass| klass.send(:include, Fog::Nullable::Array) }
 
 module Shindo
   class Tests
-
     # Generates a Shindo test that compares a hash schema to the result
     # of the passed in block returning true if they match.
     #
@@ -85,9 +84,9 @@ module Shindo
     def formats(format, strict = true)
       test('has proper format') do
         if strict
-          options = {:allow_extra_keys => false, :allow_optional_rules => true}
+          options = { :allow_extra_keys => false, :allow_optional_rules => true }
         else
-          options = {:allow_extra_keys => true, :allow_optional_rules => true}
+          options = { :allow_extra_keys => true, :allow_optional_rules => true }
         end
         validator = Fog::Schema::DataValidator.new
         valid = validator.validate(yield, format, options)

--- a/lib/fog/test_helpers/helper.rb
+++ b/lib/fog/test_helpers/helper.rb
@@ -6,13 +6,18 @@ ENV['FOG_CREDENTIAL'] = ENV['FOG_CREDENTIAL'] || 'default'
 Excon.defaults.merge!(:debug_request => true, :debug_response => true)
 
 LOREM = <<HERE
-Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+sunt in culpa qui officia deserunt mollit anim id est laborum.
 HERE
 
-require "tempfile"
+require 'tempfile'
 
 def lorem_file
-  Tempfile.new("lorem").tap do |f|
+  Tempfile.new('lorem').tap do |f|
     f.write(LOREM)
     f.rewind
   end

--- a/lib/fog/test_helpers/mock_helper.rb
+++ b/lib/fog/test_helpers/mock_helper.rb
@@ -4,9 +4,7 @@ require 'fog/core'
 #
 # FOG_MOCK=true fog
 
-if ENV["FOG_MOCK"] == "true"
-  Fog.mock!
-end
+Fog.mock! if ENV['FOG_MOCK'] == 'true'
 
 # if in mocked mode, fill in some fake credentials for us
 if Fog.mock?
@@ -55,8 +53,8 @@ if Fog.mock?
     :os_account_meta_temp_url_key     => 'os_account_meta_temp_url_key',
     :ibm_username                     => 'ibm_username',
     :ibm_password                     => 'ibm_password',
-    :joyent_username                  => "joyentuser",
-    :joyent_password                  => "joyentpass",
+    :joyent_username                  => 'joyentuser',
+    :joyent_password                  => 'joyentpass',
     :linode_api_key                   => 'linode_api_key',
     :local_root                       => '~/.fog',
     :bare_metal_cloud_password        => 'bare_metal_cloud_password',
@@ -65,8 +63,8 @@ if Fog.mock?
     :ninefold_compute_secret          => 'ninefold_compute_secret',
     :ninefold_storage_secret          => 'ninefold_storage_secret',
     :ninefold_storage_token           => 'ninefold_storage_token',
-#    :public_key_path                  => '~/.ssh/id_rsa.pub',
-#    :private_key_path                 => '~/.ssh/id_rsa',
+    # :public_key_path                  => '~/.ssh/id_rsa.pub',
+    # :private_key_path                 => '~/.ssh/id_rsa',
     :openstack_api_key                => 'openstack_api_key',
     :openstack_username               => 'openstack_username',
     :openstack_tenant                 => 'openstack_tenant',

--- a/lib/fog/test_helpers/model_helper.rb
+++ b/lib/fog/test_helpers/model_helper.rb
@@ -1,25 +1,19 @@
 def model_tests(collection, params = {}, mocks_implemented = true)
-
   tests('success') do
-
     @instance = collection.new(params)
 
-    tests("#save").succeeds do
+    tests('#save').succeeds do
       pending if Fog.mocking? && !mocks_implemented
       @instance.save
     end
 
-    if block_given?
-      yield
-    end
+    yield if block_given?
 
-    tests("#destroy").succeeds do
+    tests('#destroy').succeeds do
       pending if Fog.mocking? && !mocks_implemented
       @instance.destroy
     end
-
   end
-
 end
 
 # Generates a unique identifier with a random differentiator.
@@ -28,8 +22,6 @@ end
 # E.g. 'fog-test-1234'
 def uniq_id(base_name = 'fog-test')
   # random_differentiator
-  suffix = rand(65536).to_s(16).rjust(4, '0')
-  [base_name, suffix] * '-'
+  suffix = rand(65_536).to_s(16).rjust(4, '0')
+  [base_name, suffix].join('-')
 end
-
-

--- a/lib/fog/test_helpers/responds_to_helper.rb
+++ b/lib/fog/test_helpers/responds_to_helper.rb
@@ -1,13 +1,11 @@
 module Shindo
   class Tests
-
     def responds_to(method_names)
-      for method_name in [*method_names]
+      method_names.each do |method_name|
         tests("#respond_to?(:#{method_name})").returns(true) do
           @instance.respond_to?(method_name)
         end
       end
     end
-
   end
 end

--- a/lib/fog/test_helpers/succeeds_helper.rb
+++ b/lib/fog/test_helpers/succeeds_helper.rb
@@ -1,11 +1,9 @@
 module Shindo
   class Tests
-
     def succeeds
       test('succeeds') do
         !!instance_eval(&Proc.new)
       end
     end
-
   end
 end


### PR DESCRIPTION
@geemus I removed some warnings from the folder `fog/test_helpers` but all files in here are related to shindo.

Shouldn't this folder be removed? 
