### PR TITLE
Fixed rubocop warnings in attributes and associations

### DIFF
--- a/lib/fog/core/associations/default.rb
+++ b/lib/fog/core/associations/default.rb
@@ -1,5 +1,8 @@
 module Fog
   module Associations
+    # = Fog Default Association
+    #
+    # This class has the shared behavior between all association models.
     class Default
       attr_reader :model, :name, :aliases, :as
 

--- a/lib/fog/core/associations/many_identities.rb
+++ b/lib/fog/core/associations/many_identities.rb
@@ -1,5 +1,10 @@
 module Fog
   module Associations
+    # = Fog Multiple Association
+    #
+    # This class handles multiple association between the models.
+    # It expects the provider to return a collection of ids.
+    # The association models will be loaded based on the collection of ids.
     class ManyIdentities < Default
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__

--- a/lib/fog/core/associations/many_models.rb
+++ b/lib/fog/core/associations/many_models.rb
@@ -1,5 +1,9 @@
 module Fog
   module Associations
+    # = Fog Multiple Association
+    #
+    # This class handles multiple association between the models.
+    # It expects the provider to map the attribute with a collection of objects.
     class ManyModels < Default
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__

--- a/lib/fog/core/associations/one_identity.rb
+++ b/lib/fog/core/associations/one_identity.rb
@@ -1,5 +1,10 @@
 module Fog
   module Associations
+    # = Fog Single Association
+    #
+    # This class handles single association between the models.
+    # It expects the provider to return only the id of the association.
+    # The association model will be loaded based on the id initialized.
     class OneIdentity < Default
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__

--- a/lib/fog/core/associations/one_model.rb
+++ b/lib/fog/core/associations/one_model.rb
@@ -1,5 +1,9 @@
 module Fog
   module Associations
+    # = Fog Single Association
+    #
+    # This class handles single association between the models.
+    # It expects the provider to map the attribute with an initialized object.
     class OneModel < Default
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__

--- a/lib/fog/core/attributes/array.rb
+++ b/lib/fog/core/attributes/array.rb
@@ -1,5 +1,9 @@
 module Fog
   module Attributes
+    # = Fog Array Attribute
+    #
+    # This class handles Array attributes from the providers,
+    # converting values to Array objects
     class Array < Default
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__

--- a/lib/fog/core/attributes/boolean.rb
+++ b/lib/fog/core/attributes/boolean.rb
@@ -1,5 +1,9 @@
 module Fog
   module Attributes
+    # = Fog Boolean Attribute
+    #
+    # This class handles Boolean attributes from the providers,
+    # converting values to Boolean objects
     class Boolean < Default
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__

--- a/lib/fog/core/attributes/default.rb
+++ b/lib/fog/core/attributes/default.rb
@@ -1,5 +1,9 @@
 module Fog
   module Attributes
+    # = Fog Default Attribute
+    #
+    # This class handles the attributes without a type force.
+    # The attributes returned from the provider will keep its original values.
     class Default
       attr_reader :model, :name, :squash, :aliases, :default, :as
 

--- a/lib/fog/core/attributes/float.rb
+++ b/lib/fog/core/attributes/float.rb
@@ -1,5 +1,9 @@
 module Fog
   module Attributes
+    # = Fog Float Attribute
+    #
+    # This class handles Float attributes from the providers,
+    # converting values to Float objects
     class Float < Default
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__

--- a/lib/fog/core/attributes/integer.rb
+++ b/lib/fog/core/attributes/integer.rb
@@ -1,5 +1,9 @@
 module Fog
   module Attributes
+    # = Fog Integer Attribute
+    #
+    # This class handles Integer attributes from the providers,
+    # converting values to Integer objects
     class Integer < Default
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__

--- a/lib/fog/core/attributes/string.rb
+++ b/lib/fog/core/attributes/string.rb
@@ -1,5 +1,9 @@
 module Fog
   module Attributes
+    # = Fog String Attribute
+    #
+    # This class handles String attributes from the providers,
+    # converting values to String objects
     class String < Default
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__

--- a/lib/fog/core/attributes/time.rb
+++ b/lib/fog/core/attributes/time.rb
@@ -1,5 +1,9 @@
 module Fog
   module Attributes
+    # = Fog Time Attribute
+    #
+    # This class handles Time attributes from the providers,
+    # converting values to Time objects
     class Time < Default
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__

--- a/lib/fog/core/attributes/timestamp.rb
+++ b/lib/fog/core/attributes/timestamp.rb
@@ -1,5 +1,9 @@
 module Fog
   module Attributes
+    # = Fog Timestamp Attribute
+    #
+    # This class handles Timestamp attributes from the providers,
+    # converting Integer and String values as a real Timestamp objects
     class Timestamp < Default
       def create_setter
         model.class_eval <<-EOS, __FILE__, __LINE__


### PR DESCRIPTION
With this pull the lib folder is almost clean. All is left are warnings that we should look more carefully.

I will send another pull request with the changes on the spec folder. =)
