### PR TITLE
FIX: Output of the ERROR message of const_get method is not enough.

### DIFF
--- a/lib/fog/identity.rb
+++ b/lib/fog/identity.rb
@@ -14,10 +14,10 @@ module Fog
 
       require "fog/#{provider}/identity"
       begin
-        Fog::Identity.const_get(Fog.providers[provider]).new(attributes)
+        Fog::Identity.const_get(Fog.providers[provider])
       rescue
-        Fog.const_get(Fog.providers[provider])::Identity.new(attributes)
-      end
+        Fog.const_get(Fog.providers[provider])::Identity
+      end.new(attributes)
     end
 
     def self.providers


### PR DESCRIPTION
This PR is fix my PR #54.

If initializer of Fog::Identity::ProviderName in line 17 raises an exception,
the exception is caught by `rescue` block and eventually `NameError` will be raised in line 19.
This hides the internal exception and makes debugging hard.

``` ruby
class Fog::Identity::ProviderName
  class Real
    def initialize
        raise "error"
    end
  end
end

# No definition of Fog::ProviderName::Identity
```
