### PR TITLE
Force pre-2.2 behavior for circular variable.

### DIFF
--- a/lib/fog/core/collection.rb
+++ b/lib/fog/core/collection.rb
@@ -141,7 +141,7 @@ module Fog
   # Base class for collection classes whose 'all' method returns only a single page of results and passes the
   # 'Marker' option along as self.filters[:marker]
   class PagedCollection < Collection
-    def each(filters = filters)
+    def each(filters = filters())
       if block_given?
         begin
           page = all(filters)


### PR DESCRIPTION
Trunk currently emits a warning about the circular argument reference [here](https://github.com/fog/fog-core/blob/master/lib/fog/core/collection.rb#L144). If I'm reading [the discussion](https://bugs.ruby-lang.org/issues/10314), adding parenthesis to `filters` should force the old behavior and suppress the warning. Not much of a PR, but it's working great locally and didn't break the test suite.