### PR TITLE
[#83470576] Rescue the correct error when fetching credentials

### DIFF
--- a/lib/fog/core/service.rb
+++ b/lib/fog/core/service.rb
@@ -120,7 +120,7 @@ module Fog
       def fetch_credentials(_options)
         # attempt to load credentials from config file
         Fog.credentials.reject { |key, _value| !(recognized | requirements).include?(key) }
-      rescue LoadError
+      rescue ::Fog::Errors::LoadError
         # if there are no configured credentials, do nothing
         {}
       end


### PR DESCRIPTION
In commit 08df3056, the `LoadError` class was changed such that it
inherits from `::Fog::Errors::Error` rather than Ruby's built-in
`LoadError` object, as it was previously.

That commit omitted to update this `rescue` line, meaning that
`::Fog::Errors::LoadError` was not being rescued.
