### PR TITLE
Fix StormOnDemand require paths

### DIFF
--- a/lib/fog/account.rb
+++ b/lib/fog/account.rb
@@ -9,7 +9,7 @@ module Fog
       provider = attributes.delete(:provider).to_s.downcase.to_sym
 
       if provider == :stormondemand
-        require "fog/storm_on_demand/account"
+        require "fog/account/storm_on_demand"
         Fog::Account::StormOnDemand.new(attributes)
       else
         raise ArgumentError, "#{provider} has no account service"

--- a/lib/fog/billing.rb
+++ b/lib/fog/billing.rb
@@ -8,7 +8,7 @@ module Fog
       attributes = attributes.dup
       provider = attributes.delete(:provider).to_s.downcase.to_sym
       if provider == :stormondemand
-        require "fog/storm_on_demand/billing"
+        require "fog/billing/storm_on_demand"
         Fog::Billing::StormOnDemand.new(attributes)
       else
         raise ArgumentError, "#{provider} has no billing service"

--- a/lib/fog/compute.rb
+++ b/lib/fog/compute.rb
@@ -42,7 +42,7 @@ module Fog
           Fog::Compute::RackspaceV2.new(attributes)
         end
       when :stormondemand
-        require "fog/storm_on_demand/compute"
+        require "fog/compute/storm_on_demand"
         Fog::Compute::StormOnDemand.new(attributes)
       when :vcloud
         require "fog/vcloud/compute"

--- a/lib/fog/dns.rb
+++ b/lib/fog/dns.rb
@@ -8,7 +8,7 @@ module Fog
       attributes = attributes.dup # prevent delete from having side effects
       case provider = attributes.delete(:provider).to_s.downcase.to_sym
       when :stormondemand
-        require "fog/storm_on_demand/dns"
+        require "fog/dns/storm_on_demand"
         Fog::DNS::StormOnDemand.new(attributes)
       else
         if providers.include?(provider)

--- a/lib/fog/monitoring.rb
+++ b/lib/fog/monitoring.rb
@@ -8,7 +8,7 @@ module Fog
       attributes = attributes.dup
       provider = attributes.delete(:provider).to_s.downcase.to_sym
       if provider == :stormondemand
-        require "fog/storm_on_demand/billing"
+        require "fog/monitoring/storm_on_demand"
         Fog::Monitoring::StormOnDemand.new(attributes)
       else
         raise ArgumentError, "#{provider} has no monitoring service"

--- a/lib/fog/network.rb
+++ b/lib/fog/network.rb
@@ -9,7 +9,7 @@ module Fog
       provider = attributes.delete(:provider).to_s.downcase.to_sym
 
       if provider == :stormondemand
-        require "fog/storm_on_demand/network"
+        require "fog/network/storm_on_demand"
         return Fog::Network::StormOnDemand.new(attributes)
       elsif providers.include?(provider)
         require "fog/#{provider}/network"

--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -13,7 +13,7 @@ module Fog
         require "fog/internet_archive/storage"
         Fog::Storage::InternetArchive.new(attributes)
       when :stormondemand
-        require "fog/storm_on_demand/storage"
+        require "fog/storage/storm_on_demand"
         Fog::Storage::StormOnDemand.new(attributes)
       else
         if providers.include?(provider)

--- a/lib/fog/support.rb
+++ b/lib/fog/support.rb
@@ -9,7 +9,7 @@ module Fog
       provider = attributes.delete(:provider).to_s.downcase.to_sym
 
       if provider == :stormondemand
-        require "fog/storm_on_demand/support"
+        require "fog/support/storm_on_demand"
         Fog::Support::StormOnDemand.new(attributes)
       else
         raise ArgumentError, "#{provider} has no support service"

--- a/lib/fog/vpn.rb
+++ b/lib/fog/vpn.rb
@@ -9,7 +9,7 @@ module Fog
       provider = attributes.delete(:provider).to_s.downcase.to_sym
 
       if provider == :stormondemand
-        require "fog/storm_on_demand/vpn"
+        require "fog/vpn/storm_on_demand"
         Fog::VPN::StormOnDemand.new(attributes)
       else
         raise ArgumentError, "#{provider} has no vpn service"


### PR DESCRIPTION
This is a fix for a long term problem. This code should be disappearing
from `fog-core` but until then this has been fixed to correctly
reference the files in `fog-storm_on_demand`

This fixes https://github.com/fog/fog-storm_on_demand/issues/2
