### PR TITLE
Fix alternative require ordering

### DIFF
--- a/lib/fog/compute.rb
+++ b/lib/fog/compute.rb
@@ -52,7 +52,11 @@ module Fog
         Fog::Compute::VcloudDirector.new(attributes)
       else
         if providers.include?(provider)
-          require "fog/#{provider}/compute"
+          begin
+            require "fog/#{provider}/compute"
+          rescue LoadError
+            require "fog/compute/#{provider}"
+          end
           begin
             Fog::Compute.const_get(Fog.providers[provider])
           rescue


### PR DESCRIPTION
Earlier providers tended to have modules named `Fog::Service::Provider`
but defined in a file `fog/provider/service`

Whilst the `Fog::Compute` module dealt with the alternative namespace
(`Fog::Provider::Service`) it did not match with the clearer file naming

This rescues the `LoadError` and attempts the alternative form.

This code is all due for removal real soon now.

This fixes the same error as https://github.com/fog/fog-core/pull/110 but for `Fog::Compute[:vmfusion]`
