### PR TITLE
Simpler check for Ruby version and skip

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-require "rubygems"
-
 require "minitest/autorun"
 require "minitest/spec"
 require "minitest/stub_const"

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -94,15 +94,15 @@ describe "Fog::Storage" do
   end
 
   describe ".get_body_size" do
-    current_version = Gem::Version.new(RUBY_VERSION)
-
-    # Ruby 1.8 doesn't support string encodings, so we can't test that
-    if current_version >= Gem::Version.new("1.9.0")
-      it "doesn't alter the encoding of the string passed to it" do
+    it "doesn't alter the encoding of the string passed to it" do
+      # Ruby 1.8 doesn't support string encodings, so we can't test that
+      if RUBY_VERSION >= "1.9.3"
         body = "foo".encode("UTF-8")
         Fog::Storage.get_body_size(body)
 
         assert_equal("UTF-8", body.encoding.to_s)
+      else
+        skip
       end
     end
   end


### PR DESCRIPTION
This removes the need for Rubygems just to parse the `RUBY_VERSION`
string to ignore 1.8.7

String comparison gives us a simpler way to check this and I started
seeing errors about frozen Strings being modified related to this.

This now "skips" on any ruby < 1.9. string to ignore 1.8.7

String comparison gives us a simpler way to check this and I started
seeing errors about frozen Strings being modified related to this.

This now "skips" on any ruby < 1.9.3
