### PR TITLE
Update model.rb

### DIFF
--- a/lib/fog/core/model.rb
+++ b/lib/fog/core/model.rb
@@ -21,7 +21,7 @@ module Fog
     end
 
     def inspect
-      Thread.current[:formatador] ||= Formatador.new
+      Thread.current[:formatador] ||= ::Formatador.new
       data = "#{Thread.current[:formatador].indentation}<#{self.class.name}"
       Thread.current[:formatador].indent do
         unless self.class.attributes.empty?


### PR DESCRIPTION
I'm just a ruby newbie but this seems to work for my issue:

```
$ vagrant up 
Bringing machine 'default' up with 'libvirt' provider...
/home/pablogc/.vagrant.d/gems/gems/fog-core-1.27.3/lib/fog/formatador.rb:6:in `initialize': wrong number of arguments (0 for 1) (ArgumentError)
	from /home/pablogc/.vagrant.d/gems/gems/fog-core-1.27.3/lib/fog/core/model.rb:24:in `new'
	from /home/pablogc/.vagrant.d/gems/gems/fog-core-1.27.3/lib/fog/core/model.rb:24:in `inspect'
	from /home/pablogc/.vagrant.d/gems/gems/fog-core-1.27.3/lib/fog/core/collection.rb:19:in `inspect'
	from /home/pablogc/.vagrant.d/gems/gems/fog-core-1.27.3/lib/fog/core/collection.rb:19:in `to_s'
	from /home/pablogc/.vagrant.d/gems/gems/vagrant-libvirt-0.0.24/lib/vagrant-libvirt/action/set_name_of_domain.rb:17:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builder.rb:116:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:66:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:66:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/call.rb:53:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
	from /home/pablogc/.vagrant.d/gems/gems/vagrant-libvirt-0.0.24/lib/vagrant-libvirt/action/connect_libvirt.rb:18:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/builder.rb:116:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:66:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:66:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/machine.rb:214:in `action_raw'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/machine.rb:191:in `block in action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/environment.rb:516:in `lock'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/machine.rb:178:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/machine.rb:178:in `action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/batch_action.rb:82:in `block (2 levels) in run'
```