### PR TITLE
#merge_attributes doesn't updates masked methods.

### DIFF
--- a/lib/fog/core/attributes.rb
+++ b/lib/fog/core/attributes.rb
@@ -116,6 +116,8 @@ module Fog
             send("#{self.class.aliases[key]}=", value)
           elsif self.respond_to?("#{key}=", true)
             send("#{key}=", value)
+          elsif self.respond_to?("#{self.masks.key(key)}=", true)
+            send("#{self.masks.key(key)}=", value)
           else
             attributes[key] = value
           end

--- a/spec/fog_attribute_spec.rb
+++ b/spec/fog_attribute_spec.rb
@@ -265,6 +265,13 @@ describe "Fog::Attributes" do
     end
   end
 
+  describe ":as => :Badname" do
+    it "accepts Badname in attributes" do
+      model.merge_attributes(:Badname => "value")
+      assert_equal model.good_name, "value"
+    end
+  end
+
   describe ".has_one" do
     it "should create an instance_variable to save the association object" do
       assert_equal model.one_object, nil


### PR DESCRIPTION
Hey, all. 

Correct me if I am wrong, I'm sure that 'as' option in `attribute` method means an alias in attributes hash. For instance I have a model for Firewall: 
```ruby
class Firewall < Fog::Model
  attribute :rule_list, as: 'ruleList'
end
```

This means that I will be able to pass a hash with `ruleList` key and it will use `:rule_list=` setter, so I expect following working:
```
firewall.merge_attributes({"ruleList" => ["ACCPETS" => "ALL"]})
firewall.rule_list   # returns ["ACCPETS" => "ALL"]
```

Still this example works only if I make an alias for `:rule_list=` method to `ruleList=`. Here is a model that will work as I expect with current version of `fog-core`:
```ruby
class Firewall < Fog::Model
  attribute :rule_list, as: 'ruleList'
  alias_method :ruleList=, :rule_list=
end
```

Do I miss something or do I take it wrong? This is a simple PR that will make it working.

Thank you,
Alex L.