### PR TITLE
value is an arbitrary object and may not implement #== with string arg

### DIFF
--- a/lib/fog/core/service.rb
+++ b/lib/fog/core/service.rb
@@ -163,7 +163,7 @@ module Fog
           value_string = value.to_s.downcase
           if value.nil?
             options.delete(key)
-          elsif value == value_string.to_i.to_s
+          elsif value_string.to_i.to_s == value
             options[key] = value.to_i
           else
             options[key] = case value_string


### PR DESCRIPTION
On ruby 2.2 the changed line can emit a warning along the lines of

> Comparable#== will no more rescue exceptions of #<=> in the next release.

One case where this happens is when value is an instance of Time. I don't this this change affects the case we're trying to capture (at least not the one mentioned in the specs) but it avoids the warning.