### PR TITLE
only check for `to_time` as a last resort.

### DIFF
--- a/lib/fog/core/attributes/time.rb
+++ b/lib/fog/core/attributes/time.rb
@@ -10,6 +10,8 @@ module Fog
             def #{name}=(new_#{name})
               attributes[:#{name}] = if new_#{name}.nil? || new_#{name} == "" || new_#{name}.is_a?(::Time)
                 new_#{name}
+              elsif ::String === new_#{name}
+                ::Time.parse(new_#{name})
               elsif new_#{name}.respond_to?(:to_time)
                 new_#{name}.to_time
               else

--- a/spec/fog_attribute_spec.rb
+++ b/spec/fog_attribute_spec.rb
@@ -105,6 +105,16 @@ describe "Fog::Attributes" do
       assert_equal Time.parse(now.to_s), model.time
     end
 
+    it "returns a Time object when passed a string that is monkeypatched" do
+      now = Time.now
+      string = now.to_s
+      def string.to_time
+        "<3 <3 <3"
+      end
+      model.merge_attributes(:time => string)
+      assert_equal Time.parse(string), model.time
+    end
+
     it "returns a Time object when passed a XMLRPC::DateTime object" do
       now = XMLRPC::DateTime.new(2000, 7, 8, 10, 20, 34)
       model.merge_attributes(:time => now)


### PR DESCRIPTION
Some libraries (like Rails) will monkey patch String to add the
`to_time` method.  That means this method will function differently
depending on who monkey patched String first.  For example, [Rails changed it's default on `to_time`](https://github.com/rails/rails/commit/b79adc4323ff289aed3f5787fdfbb9542aa4f89f) to parse with regard to local time rather than UTC, which means that if you use fog with Rails, the dates returned will differ depending on which version of Rails you use.

If the object is a String, lets parse it so that the function has a
consistent return value for a given input.