### PR TITLE
[GH #138] Fix Formatador for objects defining `map`

### DIFF
--- a/lib/fog/formatador.rb
+++ b/lib/fog/formatador.rb
@@ -15,8 +15,6 @@ module Fog
       string << "#{indentation}>"
     end
 
-    
-
     def self.display_line(data)
       ::Formatador.display_line(data)
     end
@@ -69,7 +67,7 @@ module Fog
     def self.nested_objects_string(object)
       nested = ""
       return nested if object.respond_to?(:empty) and object.empty?
-      return nested unless object.respond_to?(:map)
+      return nested unless object.is_a?(Enumerable)
       nested = "#{indentation}[\n"
       indent { nested << indentation + inspect_object(object) }
       nested << "#{indentation}\n#{indentation}]\n"
@@ -83,7 +81,7 @@ module Fog
     end
 
     def self.inspect_object(object)
-      return "" unless object.respond_to?(:map)
+      return "" unless object.is_a?(Enumerable)
       object.map { |o| indentation + o.inspect }.join(", \n#{indentation}")
     end
   end

--- a/spec/formatador_spec.rb
+++ b/spec/formatador_spec.rb
@@ -108,4 +108,47 @@ describe Fog::Formatador do
       Fog::Formatador.format(@subject).must_equal @expected
     end
   end
+
+  describe "when object responds to non-enumerable '#map'" do
+    before do
+      @member = Class.new(Fog::Model) do
+        def self.name
+          "IPAddress"
+        end
+
+        # This map action is unrelated to Enumerable (See GH-138)
+        def map
+          raise "Do not call me when inspecting!"
+        end
+      end
+
+      @collection_class = Class.new(Fog::Collection) do
+        model @member
+
+        def self.name
+          "IPAddressCollection"
+        end
+
+        def all
+          self
+        end
+      end
+
+      @collection = @collection_class.new
+      @collection << @member.new
+
+      @expected = <<-EOS.gsub(/^ {6}/, "").chomp!
+        <IPAddressCollection
+          [
+                        <IPAddress
+            >    
+          ]
+        >
+      EOS
+    end
+
+    it "returns formatted representation" do
+      Fog::Formatador.format(@collection).must_equal @expected
+    end
+  end
 end


### PR DESCRIPTION
This is work to fix #138 

We check if the object passed to `Fog::Formatador` is `Enumerable` rather than checking for `map`

The class method is now used for all `Fog::Model#inspect` calls (whilst it used to just be used for collections).

This fixes fog/fog-brightbox#17