### PR TITLE
Don't raise an exception if the final yield returns true

### DIFF
--- a/lib/fog/core/wait_for.rb
+++ b/lib/fog/core/wait_for.rb
@@ -5,7 +5,9 @@ module Fog
     retries = 0
     loop do
       break if yield
-      raise Errors::TimeoutError, "The specified wait_for timeout (#{timeout} seconds) was exceeded" if duration > timeout
+      if duration > timeout
+        raise Errors::TimeoutError, "The specified wait_for timeout (#{timeout} seconds) was exceeded"
+      end
       sleep(interval.respond_to?(:call) ? interval.call(retries += 1).to_f : interval.to_f)
       duration = Time.now - start
     end

--- a/lib/fog/core/wait_for.rb
+++ b/lib/fog/core/wait_for.rb
@@ -3,14 +3,12 @@ module Fog
     duration = 0
     start = Time.now
     retries = 0
-    until yield || duration > timeout
+    loop do
+      break if yield
+      raise Errors::TimeoutError, "The specified wait_for timeout (#{timeout} seconds) was exceeded" if duration > timeout
       sleep(interval.respond_to?(:call) ? interval.call(retries += 1).to_f : interval.to_f)
       duration = Time.now - start
     end
-    if duration > timeout
-      raise Errors::TimeoutError, "The specified wait_for timeout (#{timeout} seconds) was exceeded"
-    else
-      { :duration => duration }
-    end
+    { :duration => duration }
   end
 end

--- a/spec/wait_for_spec.rb
+++ b/spec/wait_for_spec.rb
@@ -11,6 +11,13 @@ describe "Fog#wait_for" do
     end
   end
 
+  it "does not raise if successful when the wait timeout is exceeded" do
+    timeout = 2
+    i = 0
+    ret = Fog.wait_for(timeout) { i = i + 1; i > 2 }
+    assert_operator(ret[:duration], :>, timeout)
+  end
+
   it "accepts a proc to determine the sleep interval" do
     i = 0
     ret = Fog.wait_for(1, lambda { |_t| 1 }) do


### PR DESCRIPTION
Currently, if the final iteration in wait_for happens after timeout is exceeded and the yield returns true, an exception is still raised despite the successful block execution.  The included spec test fails with the existing code and passes with the new code, so it is a regression test, I guess.