### PR TITLE
Add Fog::Model equality based on identity

### DIFF
--- a/lib/fog/core/model.rb
+++ b/lib/fog/core/model.rb
@@ -24,6 +24,14 @@ module Fog
       Fog::Formatador.format(self)
     end
 
+    def ==(o)
+      if (o.identity.nil? and self.identity.nil?)
+        o.object_id == self.object_id
+      else
+        o.class == self.class and o.identity == self.identity
+      end
+    end
+
     def reload
       requires :identity
 

--- a/spec/core/model_spec.rb
+++ b/spec/core/model_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require "securerandom"
+
+class FogTestModel < Fog::Model
+  identity  :id
+end
+
+describe Fog::Model do
+  describe "#==" do
+    it "is equal if it is the same object" do
+      a = b = FogTestModel.new
+      assert_equal a, b
+    end
+
+    it "is equal if it has the same non-nil identity" do
+      id = SecureRandom.hex
+      assert_equal FogTestModel.new(:id => id), FogTestModel.new(:id => id)
+    end
+
+    it "is not equal if both have nil identity, but are different objects" do
+      refute_equal FogTestModel.new, FogTestModel.new
+    end
+
+    it "is not equal if it has a different identity" do
+      refute_equal FogTestModel.new(:id => SecureRandom.hex),
+                   FogTestModel.new(:id => SecureRandom.hex)
+    end
+  end
+end


### PR DESCRIPTION
Closes #148

N.B. This implementation means that the following will happen:

```
> a = Fog::Model.new
> b = Fog::Model.new
> a == b
=> true
> a.save
> b.save
> a == b
=> false
```

It wasn't clear to me if two unsaved models should be equal or not, so I made a judgement call.  I'm definitely open to ideas.