### PR TITLE
use Fog.interval instead of constant in Model.wait_for

### DIFF
--- a/lib/fog/core/model.rb
+++ b/lib/fog/core/model.rb
@@ -52,7 +52,7 @@ module Fog
       end
     end
 
-    def wait_for(timeout = Fog.timeout, interval = 1, &block)
+    def wait_for(timeout = Fog.timeout, interval = Fog.interval, &block)
       reload_has_succeeded = false
       duration = Fog.wait_for(timeout, interval) do # Note that duration = false if it times out
         if reload


### PR DESCRIPTION
I've been working on speeding up our test suite over in `fog-google` using VCR, and it would be extremely helpful if I could globally override the default interval for `wait_for`.  In this case, it's also a case of a [magic number](http://en.wikipedia.org/wiki/Magic_number_%28programming%29#Unnamed_numerical_constants), which, as far as I can tell, should be gotten rid of.

This is also more consistent with the definition of `Fog.wait_for` [here](https://github.com/fog/fog-core/blob/master/lib/fog/core/wait_for.rb).