### PR TITLE
Decrease Fog Memory footprint

### DIFF
--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -1,4 +1,9 @@
-require "mime/types"
+begin
+  # Use mime/types/columnar if available, for reduced memory usage
+  require 'mime/types/columnar'
+rescue LoadError
+  require 'mime/types'
+end
 
 module Fog
   module Storage


### PR DESCRIPTION
Mail 2.6.1+ has a columnar store that only loads the data that is needed for a drastically reduced memory footprint. cc/ @jeremyevans @halostatue