### PR TITLE
Fix account service to recognize all providers

### DIFF
--- a/lib/fog/account.rb
+++ b/lib/fog/account.rb
@@ -11,6 +11,9 @@ module Fog
       if provider == :stormondemand
         require "fog/account/storm_on_demand"
         Fog::Account::StormOnDemand.new(attributes)
+      elsif providers.include?(provider)
+        require "fog/#{provider}/account"
+        return Fog::Account.const_get(Fog.providers[provider]).new(attributes)
       else
         raise ArgumentError, "#{provider} has no account service"
       end

--- a/lib/fog/account.rb
+++ b/lib/fog/account.rb
@@ -13,7 +13,11 @@ module Fog
         Fog::Account::StormOnDemand.new(attributes)
       elsif providers.include?(provider)
         require "fog/#{provider}/account"
-        return Fog::Account.const_get(Fog.providers[provider]).new(attributes)
+        begin
+          Fog::Account.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::Account
+        end.new(attributes)
       else
         raise ArgumentError, "#{provider} has no account service"
       end

--- a/lib/fog/baremetal.rb
+++ b/lib/fog/baremetal.rb
@@ -7,13 +7,16 @@ module Fog
     def self.new(attributes)
       attributes = attributes.dup # Prevent delete from having side effects
       provider = attributes.delete(:provider).to_s.downcase.to_sym
-
       if providers.include?(provider)
         require "fog/#{provider}/baremetal"
-        return Fog::Baremetal.const_get(Fog.providers[provider]).new(attributes)
+        begin
+          Fog::Baremetal.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::Baremetal
+        end.new(attributes)
+      else
+        raise ArgumentError, "#{provider} has no baremetal service"
       end
-
-      raise ArgumentError, "#{provider} has no baremetal service"
     end
 
     def self.providers

--- a/lib/fog/billing.rb
+++ b/lib/fog/billing.rb
@@ -10,6 +10,13 @@ module Fog
       if provider == :stormondemand
         require "fog/billing/storm_on_demand"
         Fog::Billing::StormOnDemand.new(attributes)
+      elsif providers.include?(provider)
+        require "fog/#{provider}/billing"
+        begin
+          Fog::Account.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::Account
+        end.new(attributes)
       else
         raise ArgumentError, "#{provider} has no billing service"
       end

--- a/lib/fog/cdn.rb
+++ b/lib/fog/cdn.rb
@@ -9,9 +9,14 @@ module Fog
       provider = attributes.delete(:provider).to_s.downcase.to_sym
       if providers.include?(provider)
         require "fog/#{provider}/cdn"
-        return Fog::CDN.const_get(Fog.providers[provider]).new(attributes)
+        begin
+          Fog::CDN.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::CDN
+        end.new(attributes)
+      else
+        raise ArgumentError, "#{provider} has no cdn service"
       end
-      raise ArgumentError, "#{provider} is not a recognized cdn provider"
     end
 
     def self.providers

--- a/lib/fog/image.rb
+++ b/lib/fog/image.rb
@@ -9,9 +9,14 @@ module Fog
       provider = attributes.delete(:provider).to_s.downcase.to_sym
       if providers.include?(provider)
         require "fog/#{provider}/image"
-        return Fog::Image.const_get(Fog.providers[provider]).new(attributes)
+        begin
+          Fog::Image.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::Image
+        end.new(attributes)
+      else
+        raise ArgumentError, "#{provider} has no image service"
       end
-      raise ArgumentError, "#{provider} has no image service"
     end
 
     def self.providers

--- a/lib/fog/metering.rb
+++ b/lib/fog/metering.rb
@@ -9,10 +9,14 @@ module Fog
       provider = attributes.delete(:provider).to_s.downcase.to_sym
       if providers.include?(provider)
         require "fog/#{provider}/metering"
-        return Fog::Metering.const_get(Fog.providers[provider]).new(attributes)
+        begin
+          Fog::Metering.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::Metering
+        end.new(attributes)
+      else
+        raise ArgumentError, "#{provider} has no metering service"
       end
-
-      raise ArgumentError, "#{provider} has no identity service"
     end
 
     def self.providers

--- a/lib/fog/monitoring.rb
+++ b/lib/fog/monitoring.rb
@@ -10,6 +10,13 @@ module Fog
       if provider == :stormondemand
         require "fog/monitoring/storm_on_demand"
         Fog::Monitoring::StormOnDemand.new(attributes)
+      elsif providers.include?(provider)
+        require "fog/#{provider}/monitoring"
+        begin
+          Fog::Monitoring.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::Monitoring
+        end.new(attributes)
       else
         raise ArgumentError, "#{provider} has no monitoring service"
       end

--- a/lib/fog/network.rb
+++ b/lib/fog/network.rb
@@ -13,10 +13,14 @@ module Fog
         return Fog::Network::StormOnDemand.new(attributes)
       elsif providers.include?(provider)
         require "fog/#{provider}/network"
-        return Fog::Network.const_get(Fog.providers[provider]).new(attributes)
+        begin
+          Fog::Network.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::Network
+        end.new(attributes)
+      else
+        raise ArgumentError, "#{provider} has no network service"
       end
-
-      raise ArgumentError, "#{provider} has no network service"
     end
 
     def self.providers

--- a/lib/fog/orchestration.rb
+++ b/lib/fog/orchestration.rb
@@ -7,13 +7,16 @@ module Fog
     def self.new(attributes)
       attributes = attributes.dup # Prevent delete from having side effects
       provider = attributes.delete(:provider).to_s.downcase.to_sym
-
       if providers.include?(provider)
         require "fog/#{provider}/orchestration"
-        return Fog::Orchestration.const_get(Fog.providers[provider]).new(attributes)
+        begin
+          Fog::Orchestration.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::Orchestration
+        end.new(attributes)
+      else
+        raise ArgumentError, "#{provider} has no orchestration service"
       end
-
-      raise ArgumentError, "#{provider} has no orchestration service"
     end
 
     def self.providers

--- a/lib/fog/support.rb
+++ b/lib/fog/support.rb
@@ -11,6 +11,13 @@ module Fog
       if provider == :stormondemand
         require "fog/support/storm_on_demand"
         Fog::Support::StormOnDemand.new(attributes)
+      elsif providers.include?(provider)
+        require "fog/#{provider}/support"
+        begin
+          Fog::Support.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::Support
+        end.new(attributes)
       else
         raise ArgumentError, "#{provider} has no support service"
       end

--- a/lib/fog/volume.rb
+++ b/lib/fog/volume.rb
@@ -9,10 +9,14 @@ module Fog
       provider = attributes.delete(:provider).to_s.downcase.to_sym
       if providers.include?(provider)
         require "fog/#{provider}/volume"
-        return Fog::Volume.const_get(Fog.providers[provider]).new(attributes)
+        begin
+          Fog::Volume.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::Volume
+        end.new(attributes)
+      else
+        raise ArgumentError, "#{provider} has no volume service"
       end
-
-      raise ArgumentError, "#{provider} has no identity service"
     end
 
     def self.providers

--- a/lib/fog/vpn.rb
+++ b/lib/fog/vpn.rb
@@ -11,6 +11,13 @@ module Fog
       if provider == :stormondemand
         require "fog/vpn/storm_on_demand"
         Fog::VPN::StormOnDemand.new(attributes)
+      elsif providers.include?(provider)
+        require "fog/#{provider}/vpn"
+        begin
+          Fog::VPN.const_get(Fog.providers[provider])
+        rescue
+          Fog.const_get(Fog.providers[provider])::VPN
+        end.new(attributes)
       else
         raise ArgumentError, "#{provider} has no vpn service"
       end


### PR DESCRIPTION
I was trying to use Fog::Account on fog-softlayer and I was always getting this message error:
``` softlayer has no account service (ArgumentError) ```

So, when I take a look at this service, I've seen that it always returning this message if provider was different from :stormondemand.

Then, I fixed it!