### PR TITLE
Refactor services and fix errors

### DIFF
--- a/lib/fog/account.rb
+++ b/lib/fog/account.rb
@@ -1,8 +1,6 @@
 module Fog
   module Account
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup

--- a/lib/fog/account.rb
+++ b/lib/fog/account.rb
@@ -2,26 +2,15 @@ module Fog
   module Account
     extend Fog::ServicesMixin
 
-    def self.new(attributes)
-      attributes = attributes.dup
+    def self.new(orig_attributes)
+      attributes = orig_attributes.dup
       provider = attributes.delete(:provider).to_s.downcase.to_sym
 
       if provider == :stormondemand
         require "fog/account/storm_on_demand"
         Fog::Account::StormOnDemand.new(attributes)
-      elsif providers.include?(provider)
-        begin
-          require "fog/#{provider}/account"
-          begin
-            Fog::Account.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Account
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no account service"
-        end
       else
-        raise ArgumentError, "#{provider} is not a recognized provider"
+        super(orig_attributes)
       end
     end
 

--- a/lib/fog/baremetal.rb
+++ b/lib/fog/baremetal.rb
@@ -20,9 +20,5 @@ module Fog
         raise ArgumentError, "#{provider} is not a recognized provider"
       end
     end
-
-    def self.providers
-      Fog.services[:baremetal]
-    end
   end
 end

--- a/lib/fog/baremetal.rb
+++ b/lib/fog/baremetal.rb
@@ -1,8 +1,6 @@
 module Fog
   module Baremetal
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup # Prevent delete from having side effects

--- a/lib/fog/baremetal.rb
+++ b/lib/fog/baremetal.rb
@@ -1,24 +1,5 @@
 module Fog
   module Baremetal
     extend Fog::ServicesMixin
-
-    def self.new(attributes)
-      attributes = attributes.dup # Prevent delete from having side effects
-      provider = attributes.delete(:provider).to_s.downcase.to_sym
-      if providers.include?(provider)
-        begin
-          require "fog/#{provider}/baremetal"
-          begin
-            Fog::Baremetal.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Baremetal
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no baremetal service"
-        end
-      else
-        raise ArgumentError, "#{provider} is not a recognized provider"
-      end
-    end
   end
 end

--- a/lib/fog/billing.rb
+++ b/lib/fog/billing.rb
@@ -1,8 +1,6 @@
 module Fog
   module Billing
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup

--- a/lib/fog/billing.rb
+++ b/lib/fog/billing.rb
@@ -2,25 +2,14 @@ module Fog
   module Billing
     extend Fog::ServicesMixin
 
-    def self.new(attributes)
-      attributes = attributes.dup
+    def self.new(orig_attributes)
+      attributes = orig_attributes.dup
       provider = attributes.delete(:provider).to_s.downcase.to_sym
       if provider == :stormondemand
         require "fog/billing/storm_on_demand"
         Fog::Billing::StormOnDemand.new(attributes)
-      elsif providers.include?(provider)
-        begin
-          require "fog/#{provider}/billing"
-          begin
-            Fog::Account.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Account
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no billing service"
-        end
       else
-        raise ArgumentError, "#{provider} is not a recognized provider"
+        super(orig_attributes)
       end
     end
   end

--- a/lib/fog/billing.rb
+++ b/lib/fog/billing.rb
@@ -23,9 +23,5 @@ module Fog
         raise ArgumentError, "#{provider} is not a recognized provider"
       end
     end
-
-    def self.providers
-      Fog.services[:billing]
-    end
   end
 end

--- a/lib/fog/cdn.rb
+++ b/lib/fog/cdn.rb
@@ -20,9 +20,5 @@ module Fog
         raise ArgumentError, "#{provider} is not a recognized provider"
       end
     end
-
-    def self.providers
-      Fog.services[:cdn]
-    end
   end
 end

--- a/lib/fog/cdn.rb
+++ b/lib/fog/cdn.rb
@@ -1,8 +1,6 @@
 module Fog
   module CDN
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup # prevent delete from having side effects

--- a/lib/fog/cdn.rb
+++ b/lib/fog/cdn.rb
@@ -1,24 +1,5 @@
 module Fog
   module CDN
     extend Fog::ServicesMixin
-
-    def self.new(attributes)
-      attributes = attributes.dup # prevent delete from having side effects
-      provider = attributes.delete(:provider).to_s.downcase.to_sym
-      if providers.include?(provider)
-        begin
-          require "fog/#{provider}/cdn"
-          begin
-            Fog::CDN.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::CDN
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no cdn service"
-        end
-      else
-        raise ArgumentError, "#{provider} is not a recognized provider"
-      end
-    end
   end
 end

--- a/lib/fog/compute.rb
+++ b/lib/fog/compute.rb
@@ -76,10 +76,6 @@ module Fog
       end
     end
 
-    def self.providers
-      Fog.services[:compute]
-    end
-
     def self.servers
       servers = []
       providers.each do |provider|

--- a/lib/fog/compute.rb
+++ b/lib/fog/compute.rb
@@ -2,8 +2,8 @@ module Fog
   module Compute
     extend Fog::ServicesMixin
 
-    def self.new(attributes)
-      attributes = attributes.dup # prevent delete from having side effects
+    def self.new(orig_attributes)
+      attributes = orig_attributes.dup # prevent delete from having side effects
       provider = attributes.delete(:provider).to_s.downcase.to_sym
 
       case provider
@@ -59,20 +59,7 @@ module Fog
         require "fog/vcloud_director/compute"
         Fog::Compute::VcloudDirector.new(attributes)
       else
-        if providers.include?(provider)
-          begin
-            require "fog/#{provider}/compute"
-          rescue LoadError
-            require "fog/compute/#{provider}"
-          end
-          begin
-            Fog::Compute.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Compute
-          end.new(attributes)
-        else
-          raise ArgumentError, "#{provider} is not a recognized compute provider"
-        end
+        super(orig_attributes)
       end
     end
 

--- a/lib/fog/compute.rb
+++ b/lib/fog/compute.rb
@@ -1,8 +1,6 @@
 module Fog
   module Compute
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup # prevent delete from having side effects

--- a/lib/fog/core.rb
+++ b/lib/fog/core.rb
@@ -13,6 +13,9 @@ require "ipaddr"
 # internal core dependencies
 require File.expand_path('../core/version', __FILE__)
 
+# Mixins
+require File.expand_path('../core/services_mixin', __FILE__)
+
 require File.expand_path('../core/attributes', __FILE__)
 require File.expand_path('../core/attributes/default', __FILE__)
 require File.expand_path('../core/attributes/array', __FILE__)

--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -1,0 +1,7 @@
+module Fog
+  module ServicesMixin
+    def [](provider)
+      new(:provider => provider)
+    end
+  end
+end

--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -4,6 +4,32 @@ module Fog
       new(:provider => provider)
     end
 
+    def new(attributes)
+      attributes    = attributes.dup # Prevent delete from having side effects
+      provider      = attributes.delete(:provider).to_s.downcase.to_sym
+      provider_name = Fog.providers[provider]
+
+      if providers.include?(provider)
+        begin
+          begin
+            require "fog/#{provider}/#{service_name.downcase}"
+          rescue LoadError
+            require "fog/#{service_name.downcase}/#{provider}"
+          end
+
+          begin
+            Fog.const_get(service_name).const_get(provider_name)
+          rescue NameError  # Try to find the constant from in an alternate location
+            Fog.const_get(provider_name).const_get(service_name)
+          end.new(attributes)
+        rescue
+          raise ArgumentError, "#{provider} has no #{service_name.downcase} service"
+        end
+      else
+        raise ArgumentError, "#{provider} is not a recognized provider"
+      end
+    end
+
     def providers
       Fog.services[service_name.downcase.to_sym] || []
     end

--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -9,17 +9,13 @@ module Fog
       provider      = attributes.delete(:provider).to_s.downcase.to_sym
       provider_name = Fog.providers[provider]
 
-      if providers.include?(provider)
-        begin
-          require_service_provider_library(service_name.downcase, provider)
-          spc = service_provider_constant(service_name, provider_name)
-          spc.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no #{service_name.downcase} service"
-        end
-      else
-        raise ArgumentError, "#{provider} is not a recognized provider"
-      end
+      raise ArgumentError, "#{provider} is not a recognized provider" unless providers.include?(provider)
+
+      require_service_provider_library(service_name.downcase, provider)
+      spc = service_provider_constant(service_name, provider_name)
+      spc.new(attributes)
+    rescue
+      raise ArgumentError, "#{provider} has no #{service_name.downcase} service"
     end
 
     def providers

--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -3,5 +3,15 @@ module Fog
     def [](provider)
       new(:provider => provider)
     end
+
+    def providers
+      Fog.services[service_name.downcase.to_sym] || []
+    end
+
+    private
+
+    def service_name
+      name.split("Fog::").last
+    end
   end
 end

--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -14,7 +14,7 @@ module Fog
       require_service_provider_library(service_name.downcase, provider)
       spc = service_provider_constant(service_name, provider_name)
       spc.new(attributes)
-    rescue
+    rescue LoadError, NameError  # Only rescue errors in finding the libraries, allow connection errors through to the caller
       raise ArgumentError, "#{provider} has no #{service_name.downcase} service"
     end
 

--- a/lib/fog/dns.rb
+++ b/lib/fog/dns.rb
@@ -1,8 +1,6 @@
 module Fog
   module DNS
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup # prevent delete from having side effects

--- a/lib/fog/dns.rb
+++ b/lib/fog/dns.rb
@@ -22,10 +22,6 @@ module Fog
       end
     end
 
-    def self.providers
-      Fog.services[:dns]
-    end
-
     def self.zones
       zones = []
       providers.each do |provider|

--- a/lib/fog/dns.rb
+++ b/lib/fog/dns.rb
@@ -2,23 +2,14 @@ module Fog
   module DNS
     extend Fog::ServicesMixin
 
-    def self.new(attributes)
-      attributes = attributes.dup # prevent delete from having side effects
+    def self.new(orig_attributes)
+      attributes = orig_attributes.dup # prevent delete from having side effects
       case provider = attributes.delete(:provider).to_s.downcase.to_sym
       when :stormondemand
         require "fog/dns/storm_on_demand"
         Fog::DNS::StormOnDemand.new(attributes)
       else
-        if providers.include?(provider)
-          require "fog/#{provider}/dns"
-          begin
-            Fog::DNS.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::DNS
-          end.new(attributes)
-        else
-          raise ArgumentError, "#{provider} is not a recognized dns provider"
-        end
+        super(orig_attributes)
       end
     end
 

--- a/lib/fog/identity.rb
+++ b/lib/fog/identity.rb
@@ -1,8 +1,6 @@
 module Fog
   module Identity
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup # Prevent delete from having side effects

--- a/lib/fog/identity.rb
+++ b/lib/fog/identity.rb
@@ -1,21 +1,5 @@
 module Fog
   module Identity
     extend Fog::ServicesMixin
-
-    def self.new(attributes)
-      attributes = attributes.dup # Prevent delete from having side effects
-      provider = attributes.delete(:provider).to_s.downcase.to_sym
-
-      unless providers.include?(provider)
-        raise ArgumentError, "#{provider} has no identity service"
-      end
-
-      require "fog/#{provider}/identity"
-      begin
-        Fog::Identity.const_get(Fog.providers[provider])
-      rescue
-        Fog.const_get(Fog.providers[provider])::Identity
-      end.new(attributes)
-    end
   end
 end

--- a/lib/fog/identity.rb
+++ b/lib/fog/identity.rb
@@ -17,9 +17,5 @@ module Fog
         Fog.const_get(Fog.providers[provider])::Identity
       end.new(attributes)
     end
-
-    def self.providers
-      Fog.services[:identity]
-    end
   end
 end

--- a/lib/fog/image.rb
+++ b/lib/fog/image.rb
@@ -1,24 +1,5 @@
 module Fog
   module Image
     extend Fog::ServicesMixin
-
-    def self.new(attributes)
-      attributes = attributes.dup # Prevent delete from having side effects
-      provider = attributes.delete(:provider).to_s.downcase.to_sym
-      if providers.include?(provider)
-        begin
-          require "fog/#{provider}/image"
-          begin
-            Fog::Image.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Image
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no image service"
-        end
-      else
-        raise ArgumentError, "#{provider} is not a recognized provider"
-      end
-    end
   end
 end

--- a/lib/fog/image.rb
+++ b/lib/fog/image.rb
@@ -1,8 +1,6 @@
 module Fog
   module Image
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup # Prevent delete from having side effects

--- a/lib/fog/image.rb
+++ b/lib/fog/image.rb
@@ -20,9 +20,5 @@ module Fog
         raise ArgumentError, "#{provider} is not a recognized provider"
       end
     end
-
-    def self.providers
-      Fog.services[:image]
-    end
   end
 end

--- a/lib/fog/metering.rb
+++ b/lib/fog/metering.rb
@@ -20,9 +20,5 @@ module Fog
         raise ArgumentError, "#{provider} is not a recognized provider"
       end
     end
-
-    def self.providers
-      Fog.services[:metering]
-    end
   end
 end

--- a/lib/fog/metering.rb
+++ b/lib/fog/metering.rb
@@ -1,24 +1,5 @@
 module Fog
   module Metering
     extend Fog::ServicesMixin
-
-    def self.new(attributes)
-      attributes = attributes.dup # Prevent delete from having side effects
-      provider = attributes.delete(:provider).to_s.downcase.to_sym
-      if providers.include?(provider)
-        begin
-          require "fog/#{provider}/metering"
-          begin
-            Fog::Metering.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Metering
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no metering service"
-        end
-      else
-        raise ArgumentError, "#{provider} is not a recognized provider"
-      end
-    end
   end
 end

--- a/lib/fog/metering.rb
+++ b/lib/fog/metering.rb
@@ -1,8 +1,6 @@
 module Fog
   module Metering
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup # Prevent delete from having side effects

--- a/lib/fog/monitoring.rb
+++ b/lib/fog/monitoring.rb
@@ -23,9 +23,5 @@ module Fog
         raise ArgumentError, "#{provider} is not a recognized provider"
       end
     end
-
-    def self.providers
-      Fog.services[:monitoring]
-    end
   end
 end

--- a/lib/fog/monitoring.rb
+++ b/lib/fog/monitoring.rb
@@ -1,8 +1,6 @@
 module Fog
   module Monitoring
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup

--- a/lib/fog/monitoring.rb
+++ b/lib/fog/monitoring.rb
@@ -2,25 +2,14 @@ module Fog
   module Monitoring
     extend Fog::ServicesMixin
 
-    def self.new(attributes)
-      attributes = attributes.dup
+    def self.new(orig_attributes)
+      attributes = orig_attributes.dup
       provider = attributes.delete(:provider).to_s.downcase.to_sym
       if provider == :stormondemand
         require "fog/monitoring/storm_on_demand"
         Fog::Monitoring::StormOnDemand.new(attributes)
-      elsif providers.include?(provider)
-        begin
-          require "fog/#{provider}/monitoring"
-          begin
-            Fog::Monitoring.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Monitoring
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no monitoring service"
-        end
       else
-        raise ArgumentError, "#{provider} is not a recognized provider"
+        super(orig_attributes)
       end
     end
   end

--- a/lib/fog/network.rb
+++ b/lib/fog/network.rb
@@ -2,26 +2,15 @@ module Fog
   module Network
     extend Fog::ServicesMixin
 
-    def self.new(attributes)
-      attributes = attributes.dup # Prevent delete from having side effects
+    def self.new(orig_attributes)
+      attributes = orig_attributes.dup # Prevent delete from having side effects
       provider = attributes.delete(:provider).to_s.downcase.to_sym
 
       if provider == :stormondemand
         require "fog/network/storm_on_demand"
         return Fog::Network::StormOnDemand.new(attributes)
-      elsif providers.include?(provider)
-        begin
-          require "fog/#{provider}/network"
-          begin
-            Fog::Network.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Network
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no network service"
-        end
       else
-        raise ArgumentError, "#{provider} is not a recognized provider"
+        super(orig_attributes)
       end
     end
   end

--- a/lib/fog/network.rb
+++ b/lib/fog/network.rb
@@ -24,9 +24,5 @@ module Fog
         raise ArgumentError, "#{provider} is not a recognized provider"
       end
     end
-
-    def self.providers
-      Fog.services[:network]
-    end
   end
 end

--- a/lib/fog/network.rb
+++ b/lib/fog/network.rb
@@ -1,8 +1,6 @@
 module Fog
   module Network
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup # Prevent delete from having side effects

--- a/lib/fog/orchestration.rb
+++ b/lib/fog/orchestration.rb
@@ -1,8 +1,6 @@
 module Fog
   module Orchestration
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup # Prevent delete from having side effects

--- a/lib/fog/orchestration.rb
+++ b/lib/fog/orchestration.rb
@@ -1,24 +1,5 @@
 module Fog
   module Orchestration
     extend Fog::ServicesMixin
-
-    def self.new(attributes)
-      attributes = attributes.dup # Prevent delete from having side effects
-      provider = attributes.delete(:provider).to_s.downcase.to_sym
-      if providers.include?(provider)
-        begin
-          require "fog/#{provider}/orchestration"
-          begin
-            Fog::Orchestration.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Orchestration
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no orchestration service"
-        end
-      else
-        raise ArgumentError, "#{provider} is not a recognized provider"
-      end
-    end
   end
 end

--- a/lib/fog/orchestration.rb
+++ b/lib/fog/orchestration.rb
@@ -20,9 +20,5 @@ module Fog
         raise ArgumentError, "#{provider} is not a recognized provider"
       end
     end
-
-    def self.providers
-      Fog.services[:orchestration]
-    end
   end
 end

--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -7,9 +7,7 @@ end
 
 module Fog
   module Storage
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup # prevent delete from having side effects

--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -85,9 +85,5 @@ module Fog
         }
       }
     end
-
-    def self.providers
-      Fog.services[:storage]
-    end
   end
 end

--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -9,8 +9,8 @@ module Fog
   module Storage
     extend Fog::ServicesMixin
 
-    def self.new(attributes)
-      attributes = attributes.dup # prevent delete from having side effects
+    def self.new(orig_attributes)
+      attributes = orig_attributes.dup # prevent delete from having side effects
       case provider = attributes.delete(:provider).to_s.downcase.to_sym
       when :internetarchive
         require "fog/internet_archive/storage"
@@ -19,16 +19,7 @@ module Fog
         require "fog/storage/storm_on_demand"
         Fog::Storage::StormOnDemand.new(attributes)
       else
-        if providers.include?(provider)
-          require "fog/#{provider}/storage"
-          begin
-            Fog::Storage.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Storage
-          end.new(attributes)
-        else
-          raise ArgumentError, "#{provider} is not a recognized storage provider"
-        end
+        super(orig_attributes)
       end
     end
 

--- a/lib/fog/support.rb
+++ b/lib/fog/support.rb
@@ -2,26 +2,15 @@ module Fog
   module Support
     extend Fog::ServicesMixin
 
-    def self.new(attributes)
-      attributes = attributes.dup
+    def self.new(orig_attributes)
+      attributes = orig_attributes.dup
       provider = attributes.delete(:provider).to_s.downcase.to_sym
 
       if provider == :stormondemand
         require "fog/support/storm_on_demand"
         Fog::Support::StormOnDemand.new(attributes)
-      elsif providers.include?(provider)
-        begin
-          require "fog/#{provider}/support"
-          begin
-            Fog::Support.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Support
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no support service"
-        end
       else
-        raise ArgumentError, "#{provider} is not a recognized provider"
+        super(orig_attributes)
       end
     end
   end

--- a/lib/fog/support.rb
+++ b/lib/fog/support.rb
@@ -1,8 +1,6 @@
 module Fog
   module Support
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup

--- a/lib/fog/support.rb
+++ b/lib/fog/support.rb
@@ -24,9 +24,5 @@ module Fog
         raise ArgumentError, "#{provider} is not a recognized provider"
       end
     end
-
-    def self.providers
-      Fog.services[:support]
-    end
   end
 end

--- a/lib/fog/volume.rb
+++ b/lib/fog/volume.rb
@@ -1,24 +1,5 @@
 module Fog
   module Volume
     extend Fog::ServicesMixin
-
-    def self.new(attributes)
-      attributes = attributes.dup # Prevent delete from having side effects
-      provider = attributes.delete(:provider).to_s.downcase.to_sym
-      if providers.include?(provider)
-        begin
-          require "fog/#{provider}/volume"
-          begin
-            Fog::Volume.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::Volume
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no volume service"
-        end
-      else
-        raise ArgumentError, "#{provider} is not a recognized provider"
-      end
-    end
   end
 end

--- a/lib/fog/volume.rb
+++ b/lib/fog/volume.rb
@@ -20,9 +20,5 @@ module Fog
         raise ArgumentError, "#{provider} is not a recognized provider"
       end
     end
-
-    def self.providers
-      Fog.services[:volume]
-    end
   end
 end

--- a/lib/fog/volume.rb
+++ b/lib/fog/volume.rb
@@ -1,8 +1,6 @@
 module Fog
   module Volume
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup # Prevent delete from having side effects

--- a/lib/fog/vpn.rb
+++ b/lib/fog/vpn.rb
@@ -1,8 +1,6 @@
 module Fog
   module VPN
-    def self.[](provider)
-      new(:provider => provider)
-    end
+    extend Fog::ServicesMixin
 
     def self.new(attributes)
       attributes = attributes.dup

--- a/lib/fog/vpn.rb
+++ b/lib/fog/vpn.rb
@@ -2,26 +2,15 @@ module Fog
   module VPN
     extend Fog::ServicesMixin
 
-    def self.new(attributes)
-      attributes = attributes.dup
+    def self.new(orig_attributes)
+      attributes = orig_attributes.dup
       provider = attributes.delete(:provider).to_s.downcase.to_sym
 
       if provider == :stormondemand
         require "fog/vpn/storm_on_demand"
         Fog::VPN::StormOnDemand.new(attributes)
-      elsif providers.include?(provider)
-        begin
-          require "fog/#{provider}/vpn"
-          begin
-            Fog::VPN.const_get(Fog.providers[provider])
-          rescue
-            Fog.const_get(Fog.providers[provider])::VPN
-          end.new(attributes)
-        rescue
-          raise ArgumentError, "#{provider} has no vpn service"
-        end
       else
-        raise ArgumentError, "#{provider} is not a recognized provider"
+        super(orig_attributes)
       end
     end
   end

--- a/lib/fog/vpn.rb
+++ b/lib/fog/vpn.rb
@@ -24,9 +24,5 @@ module Fog
         raise ArgumentError, "#{provider} is not a recognized provider"
       end
     end
-
-    def self.providers
-      Fog.services[:vpn]
-    end
   end
 end


### PR DESCRIPTION
Only rescue errors related to loading and finding components

Allow connection errors to bubble up to the caller.  Previous changes were rescuing connection errors and re-raising them as ArgumentErrors leading people to believe that "openstack has no network service" for example. However, this was not the case, openstack does have a network service registered in fog, the proper library was loaded, but there was an issue connecting to the server.

See changes in: https://github.com/fog/fog-core/commit/36e2824c8467402697edc188cc8779ced659e31c
