### PR TITLE
Expose the name of the identity attribute

### DIFF
--- a/lib/fog/core/attributes.rb
+++ b/lib/fog/core/attributes.rb
@@ -101,12 +101,16 @@ module Fog
         copy
       end
 
+      def identity_name
+        self.class.instance_variable_get("@identity")
+      end
+
       def identity
-        send(self.class.instance_variable_get("@identity"))
+        send(identity_name)
       end
 
       def identity=(new_identity)
-        send("#{self.class.instance_variable_get("@identity")}=", new_identity)
+        send("#{identity_name}=", new_identity)
       end
 
       def merge_attributes(new_attributes = {})


### PR DESCRIPTION
It's nice to have name of the identity attribute exposed as
public. So it can be used e.g. for selecting uniq elements
of the Fog::Collection