### PR TITLE
add new optioin nested_aliases to attribute.

### DIFF
--- a/lib/fog/core/attributes.rb
+++ b/lib/fog/core/attributes.rb
@@ -130,6 +130,7 @@ module Fog
         end
 
         self.class.nested_aliases.each_pair do |key, value|
+          next if attributes[value]
           attributes[value] = _get_nested_value(new_attributes, key.split("."))
         end
 

--- a/lib/fog/core/attributes.rb
+++ b/lib/fog/core/attributes.rb
@@ -197,8 +197,7 @@ module Fog
 
       # Dig value from new_attributes recursively
       # Returns String or Array
-      def _get_nested_value(attributes = {}, keys)
-        return nil unless attributes
+      def _get_nested_value(attributes = {}, keys = [])
         return attributes unless attributes.is_a?(Hash)
         if keys.length > 1
           _get_nested_value(attributes[keys.first], keys.drop(1))

--- a/lib/fog/core/attributes.rb
+++ b/lib/fog/core/attributes.rb
@@ -9,6 +9,10 @@ module Fog
         @aliases ||= {}
       end
 
+      def nested_aliases
+        @nested_aliases ||= {}
+      end
+
       def associations
         @associations ||= {}
       end
@@ -124,6 +128,11 @@ module Fog
             attributes[key] = value
           end
         end
+
+        self.class.nested_aliases.each_pair do |key, value|
+          attributes[value] = _get_nested_value(new_attributes, key.split("."))
+        end
+
         self
       end
 
@@ -183,6 +192,18 @@ module Fog
       def remap_attributes(attributes, mapping)
         mapping.each_pair do |key, value|
           attributes[value] = attributes.delete(key) if attributes.key?(key)
+        end
+      end
+
+      # Dig value from new_attributes recursively
+      # Returns String or Array
+      def _get_nested_value(attributes = {}, keys)
+        return nil unless attributes
+        return attributes unless attributes.is_a?(Hash)
+        if keys.length > 1
+          _get_nested_value(attributes[keys.first], keys.drop(1))
+        else
+          attributes[keys.first]
         end
       end
     end

--- a/lib/fog/core/attributes/default.rb
+++ b/lib/fog/core/attributes/default.rb
@@ -5,7 +5,7 @@ module Fog
     # This class handles the attributes without a type force.
     # The attributes returned from the provider will keep its original values.
     class Default
-      attr_reader :model, :name, :squash, :aliases, :default, :as
+      attr_reader :model, :name, :squash, :aliases, :default, :as, :nested_aliases
 
       def initialize(model, name, options)
         @model = model
@@ -13,11 +13,13 @@ module Fog
         @name = name
         @squash = options.fetch(:squash, false)
         @aliases = options.fetch(:aliases, [])
+        @nested_aliases = options.fetch(:nested_aliases, [])
         @default = options[:default]
         @as = options.fetch(:as, name)
         create_setter
         create_getter
         create_aliases
+        create_nested_aliases
         set_defaults
         create_mask
       end
@@ -63,6 +65,12 @@ module Fog
       def create_aliases
         Array(aliases).each do |alias_name|
           model.aliases[alias_name] = name
+        end
+      end
+
+      def create_nested_aliases
+        Array(nested_aliases).each do |alias_name|
+          model.nested_aliases[alias_name] = name
         end
       end
 


### PR DESCRIPTION
Hi, I added new option to attribute.

I would like to use value which in nested json as model attribute directly.

----

For example. 

When a provider returns nested key values like below.

```
{
      "Index": 0,
      "ID": "112700xxxxx",
      "Name": "example",
      "Description": "desc",
      "Settings": {
        "DNS": {
          "ResourceRecordSets": []
        }
      },
      "Status": {
        "Zone": "example.com",
        "NS": [
          "ns1.gslb2.sakura.ne.jp",
          "ns2.gslb2.sakura.ne.jp"
        ]
      }
}
```

We can use `:nested_aliases` to collect into attribute.

```
        attribute :zone, :nested_aliases => 'Status.Zone'
        attribute :nameservers, :nested_aliases => 'Stat.NS'
```

It creates below object.

```
=>   <Fog::DNS::SakuraCloud::Zone
    id="11270077xxxx",
    name="example.com",
    description="desc",
    zone="example.com",
    nameservers=["ns1.gslb2.sakura.ne.jp", "ns2.gslb2.sakura.ne.jp"],
```
