### PR TITLE
Locking the net-ssh for Ruby <2.0

### DIFF
--- a/fog-core.gemspec
+++ b/fog-core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("formatador", "~> 0.2")
   spec.add_dependency("mime-types")
   spec.add_dependency("net-scp", "~> 1.1")
-  spec.add_dependency("net-ssh", ">= 2.1.3")
+  spec.add_dependency("net-ssh", ">= 2.1.3", "< 3.0")
 
   spec.add_development_dependency("coveralls")
   spec.add_development_dependency("minitest")


### PR DESCRIPTION
Looking at the dep graph, it's fog-core's dependency net-ssh, which just updated a couple of hours ago:
https://rubygems.org/gems/net-ssh/
3.0.1 - September 25, 2015 (177 KB)
This breaks gem deps on Ruby <2.0