### PR TITLE
loosen requirements around net-ssh/net-scp and ruby version

### DIFF
--- a/fog-core.gemspec
+++ b/fog-core.gemspec
@@ -17,14 +17,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 1.9'
 
   spec.add_dependency("builder")
   spec.add_dependency("excon", "~> 0.45")
   spec.add_dependency("formatador", "~> 0.2")
   spec.add_dependency("mime-types")
-  spec.add_dependency("net-scp", "~> 1.1")
-  spec.add_dependency("net-ssh", ">= 2.1.3", "< 3.0")
 
   spec.add_development_dependency("coveralls")
   spec.add_development_dependency("minitest")

--- a/lib/fog/compute/models/server.rb
+++ b/lib/fog/compute/models/server.rb
@@ -65,7 +65,6 @@ module Fog
       end
 
       def scp(local_path, remote_path, upload_options = {})
-        require "net/scp"
         requires :ssh_ip_address, :username
 
         Fog::SCP.new(ssh_ip_address, username, ssh_options).upload(local_path, remote_path, upload_options)
@@ -74,14 +73,12 @@ module Fog
       alias_method :scp_upload, :scp
 
       def scp_download(remote_path, local_path, download_options = {})
-        require "net/scp"
         requires :ssh_ip_address, :username
 
         Fog::SCP.new(ssh_ip_address, username, ssh_options).download(remote_path, local_path, download_options)
       end
 
       def ssh(commands, options = {}, &blk)
-        require "net/ssh"
         requires :ssh_ip_address, :username
 
         options = ssh_options.merge(options)

--- a/lib/fog/core/scp.rb
+++ b/lib/fog/core/scp.rb
@@ -40,7 +40,12 @@ module Fog
 
     class Real
       def initialize(address, username, options)
-        require "net/scp"
+        begin
+          require "net/scp"
+        rescue LoadError
+          Fog::Logger.warning("'net/ssh' missing, please install and try again.")
+          exit(1)
+        end
 
         key_manager = Net::SSH::Authentication::KeyManager.new(nil, options)
 

--- a/lib/fog/core/ssh.rb
+++ b/lib/fog/core/ssh.rb
@@ -34,7 +34,12 @@ module Fog
 
     class Real
       def initialize(address, username, options)
-        require "net/ssh"
+        begin
+          require "net/ssh"
+        rescue LoadError
+          Fog::Logger.warning("'net/ssh' missing, please install and try again.")
+          exit(1)
+        end
 
         key_manager = Net::SSH::Authentication::KeyManager.new(nil, options)
 


### PR DESCRIPTION
first stab at making 1.9 still a thing. Might even remove the ruby require to allow this to more easily go onto 1.x series (and then get back onto the 2.x train).