### PR TITLE
Don't eagerload auto-loaded service classes in Fog::Mock.reset.

### DIFF
--- a/lib/fog/core/mock.rb
+++ b/lib/fog/core/mock.rb
@@ -91,10 +91,13 @@ module Fog
     def self.reset
       mocked_services = []
       Fog.constants.map do |x|
+        next if Fog.autoload?(x)
         x_const = Fog.const_get(x)
         x_const.respond_to?(:constants) && x_const.constants.map do |y|
+          next if x_const.autoload?(y)
           y_const = x_const.const_get(y)
           y_const.respond_to?(:constants) && y_const.constants.map do |z|
+            next if y_const.autoload?(z)
             mocked_services << y_const.const_get(z) if z.to_sym == :Mock
           end
         end


### PR DESCRIPTION
If the service classes haven't been loaded yet, they cannot have been used in any mocked tests, so there's nothing to be gained by loading them to clear out state. Eager-loading isn't just an efficiency issue -- eagerly loading classes may unnecessarily conflict with the rest of the dependency graph and can cause contrived breakages if a service doesn't run particularly well on a given platform.