### PR TITLE
Remove hp from the providers list

### DIFF
--- a/lib/fog/compute.rb
+++ b/lib/fog/compute.rb
@@ -10,17 +10,6 @@ module Fog
       when :gogrid
         require "fog/go_grid/compute"
         Fog::Compute::GoGrid.new(attributes)
-      when :hp
-        version = attributes.delete(:version)
-        version = version.to_s.downcase.to_sym unless version.nil?
-        if version == :v2
-          require "fog/hp/compute_v2"
-          Fog::Compute::HPV2.new(attributes)
-        else
-          Fog::Logger.deprecation "HP Cloud Compute V1 service will be soon deprecated. Please use `:version => v2` attribute to use HP Cloud Compute V2 service."
-          require "fog/hp/compute"
-          Fog::Compute::HP.new(attributes)
-        end
       when :new_servers
         require "fog/bare_metal_cloud/compute"
         Fog::Logger.deprecation "`new_servers` is deprecated. Please use `bare_metal_cloud` instead."


### PR DESCRIPTION
Remove hp from the list since their service has shutdown and fog/fog no longer has it.
Refer fog/fog#3854