### PR TITLE
Re-raise LoadError rather than exiting

### DIFF
--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -11,7 +11,7 @@ module Fog
           require 'mime/types'
         rescue LoadError
           Fog::Logger.warning("'mime-types' missing, please install and try again.")
-          exit(1)
+          raise
         end
       end
 


### PR DESCRIPTION
Re-raise LoadError when unable to require `mime/types` rather than exiting - the latter causes any application *using* fog to exit, which is a really crappy thing to run in to on accident for a web app