### PR TITLE
change service not found error type to Fog::Errors::Notfound

### DIFF
--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -15,7 +15,7 @@ module Fog
       spc = service_provider_constant(service_name, provider_name)
       spc.new(attributes)
     rescue LoadError, NameError  # Only rescue errors in finding the libraries, allow connection errors through to the caller
-      raise ArgumentError, "#{provider} has no #{service_name.downcase} service"
+      raise NotFound, "#{provider} has no #{service_name.downcase} service"
     end
 
     def providers


### PR DESCRIPTION
Use `Notfound` error instead of `ArgumentError` when the service was not found,
It could be very nice and more comprehensive.

Project like MIQ try to catch NotFound for not found service in provider catalog
https://github.com/Ladas/manageiq/blob/c836fdf2567122193ec54d237bc07df814abe407/gems/pending/openstack/openstack_handle/handle.rb#L75