### PR TITLE
Revert "change service not found error type to Fog::Errors::Notfound"

### DIFF
--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -15,7 +15,7 @@ module Fog
       spc = service_provider_constant(service_name, provider_name)
       spc.new(attributes)
     rescue LoadError, NameError  # Only rescue errors in finding the libraries, allow connection errors through to the caller
-      raise NotFound, "#{provider} has no #{service_name.downcase} service"
+      raise ArgumentError, "#{provider} has no #{service_name.downcase} service"
     end
 
     def providers


### PR DESCRIPTION
Reverts fog/fog-core#181

@geemus Finally @Ladas from MIQ ask for type of error more specify like `Fog::Error::ServiceNotFound`,
If you are agree with this, I will remake a new PR, sorry for confusing