### PR TITLE
fix string freeze issue for ruby 2.3

### DIFF
--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -42,7 +42,7 @@ module Fog
     def self.get_body_size(body)
       if body.respond_to?(:encoding)
         original_encoding = body.encoding
-        body.force_encoding('BINARY')
+        body = body.dup.force_encoding('BINARY')
       end
 
       size = if body.respond_to?(:bytesize)

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -67,6 +67,7 @@ describe "Fog::Storage" do
       module Storage
         class BothWays
           attr_reader :args
+
           def initialize(args)
             @args = args
           end
@@ -101,6 +102,15 @@ describe "Fog::Storage" do
         Fog::Storage.get_body_size(body)
 
         assert_equal("UTF-8", body.encoding.to_s)
+      else
+        skip
+      end
+    end
+
+    it "respects frozen strings" do
+      if RUBY_VERSION >= "2.3.0"
+        body = "foo".freeze
+        Fog::Storage.get_body_size(body)
       else
         skip
       end


### PR DESCRIPTION
I hit this issue in tests using fog-aws mock services.