### PR TITLE
Only dup strings that are frozen

### DIFF
--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -42,7 +42,8 @@ module Fog
     def self.get_body_size(body)
       if body.respond_to?(:encoding)
         original_encoding = body.encoding
-        body = body.dup.force_encoding('BINARY')
+        body = body.dup if body.frozen?
+        body = body.force_encoding('BINARY')
       end
 
       size = if body.respond_to?(:bytesize)


### PR DESCRIPTION
A recent change (c2e720e) allowed you to pass frozen strings as the body to a new file without raising a `RuntimeError` when fog tried to call `force_encoding` on it. This is fantastic, and I can't wait for the next release so we can take advantage of it.

One thing I thought might be worth discussing is that `dup`ing every time could have a performance impact, so we could just do it when the string is frozen, and otherwise keep the original behaviour.

Does this sound sensible?

I've not written a test for this because there's already one to test the correct behaviour when we pass a frozen string. If you think there's something more we could cover with a test let me know.