### PR TITLE
Fixing namespace constant detection

### DIFF
--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -31,9 +31,9 @@ module Fog
     end
 
     def service_provider_constant(service_name, provider_name)
-      Fog.const_get(service_name).const_get(provider_name)
+      Fog.const_get(service_name).const_get(provider_name, false)
     rescue NameError  # Try to find the constant from in an alternate location
-      Fog.const_get(provider_name).const_get(service_name)
+      Fog.const_get(provider_name).const_get(service_name, false)
     end
 
     def service_name


### PR DESCRIPTION
- Disabled inherit option on `const_get` in `service_provider_constant` so it doesn't search the ancestors and `Object`.

This should fix https://github.com/fog/fog-google/issues/123

/CC  @geemus @tokengeek @plribeiro3000 PTAL, since I'm less familiar with `fog-core` code.