### PR TITLE
fix #const_get lookup arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ gemfile:
   - Gemfile
 
 rvm:
+  - 1.8.7
+  - 1.9.3
   - 2.0.0
   - 2.2.0
   - jruby9k

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ gemfile:
   - Gemfile
 
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.2.0
@@ -17,6 +16,8 @@ script: bundle exec rake travis
 
 matrix:
   include:
+    - rvm: 1.8.7
+      gemfile: Gemfile18
     - rvm: 2.1.0
       gemfile: Gemfile
       env: COVERAGE=true

--- a/Gemfile18
+++ b/Gemfile18
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'rake', '~> 10.1.1'

--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -36,9 +36,13 @@ module Fog
       Fog.const_get(provider_name).const_get(*const_get_args(service_name))
     end
 
+    # Ruby 1.8 does not support the second 'inherit' argument to #const_get
     def const_get_args(*args)
-      args += [false] unless RUBY_VERSION < '1.9'
-      args
+      if RUBY_VERSION < '1.9'
+        args
+      else
+        args + [false]
+      end
     end
 
     def service_name

--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -31,9 +31,19 @@ module Fog
     end
 
     def service_provider_constant(service_name, provider_name)
-      Fog.const_get(service_name).const_get(provider_name, false)
+      const_get_args = [provider_name]
+      const_get_args << false if RUBY_VERSION < '1.9'
+
+      Fog.const_get(service_name).const_get(*const_get_args)
     rescue NameError  # Try to find the constant from in an alternate location
-      Fog.const_get(provider_name).const_get(service_name, false)
+      provider_service_constant(provider_name, service_name)
+    end
+
+    def provider_service_constant(provider_name, service_name)
+      const_get_args = [service_name]
+      const_get_args << false if RUBY_VERSION < '1.9'
+
+      Fog.const_get(provider_name).const_get(*const_get_args)
     end
 
     def service_name

--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -32,7 +32,7 @@ module Fog
 
     def service_provider_constant(service_name, provider_name)
       const_get_args = [provider_name]
-      const_get_args << false if RUBY_VERSION < '1.9'
+      const_get_args << false unless RUBY_VERSION < '1.9'
 
       Fog.const_get(service_name).const_get(*const_get_args)
     rescue NameError  # Try to find the constant from in an alternate location
@@ -41,7 +41,7 @@ module Fog
 
     def provider_service_constant(provider_name, service_name)
       const_get_args = [service_name]
-      const_get_args << false if RUBY_VERSION < '1.9'
+      const_get_args << false unless RUBY_VERSION < '1.9'
 
       Fog.const_get(provider_name).const_get(*const_get_args)
     end

--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -31,19 +31,14 @@ module Fog
     end
 
     def service_provider_constant(service_name, provider_name)
-      const_get_args = [provider_name]
-      const_get_args << false unless RUBY_VERSION < '1.9'
-
-      Fog.const_get(service_name).const_get(*const_get_args)
+      Fog.const_get(service_name).const_get(*const_get_args(provider_name))
     rescue NameError  # Try to find the constant from in an alternate location
-      provider_service_constant(provider_name, service_name)
+      Fog.const_get(provider_name).const_get(*const_get_args(service_name))
     end
 
-    def provider_service_constant(provider_name, service_name)
-      const_get_args = [service_name]
-      const_get_args << false unless RUBY_VERSION < '1.9'
-
-      Fog.const_get(provider_name).const_get(*const_get_args)
+    def const_get_args(*args)
+      args += [false] unless RUBY_VERSION < '1.9'
+      args
     end
 
     def service_name


### PR DESCRIPTION
Second method argument not available in ruby < 1.9

```
 tests/models/cdn/distribution_tests.rb
      Fog::CDN[:aws] | distribution (aws, cdn)
    wrong number of arguments (2 for 1) (ArgumentError)
      /home/travis/.rvm/gems/ruby-1.8.7-p374/gems/fog-core-1.41.0/lib/fog/core/services_mixin.rb:34:in `const_get'
      /home/travis/.rvm/gems/ruby-1.8.7-p374/gems/fog-core-1.41.0/lib/fog/core/services_mixin.rb:34:in `service_provider_constant'
      /home/travis/.rvm/gems/ruby-1.8.7-p374/gems/fog-core-1.41.0/lib/fog/core/services_mixin.rb:15:in `new'
      /home/travis/.rvm/gems/ruby-1.8.7-p374/gems/fog-core-1.41.0/lib/fog/core/services_mixin.rb:4:in `[]'
      ./tests/models/cdn/distribution_tests.rb:3
```

https://travis-ci.org/fog/fog-aws/jobs/141660726