### PR TITLE
Remove digitalocean version 2 and bump version

### DIFF
--- a/lib/fog/compute.rb
+++ b/lib/fog/compute.rb
@@ -28,16 +28,6 @@ module Fog
           require "fog/rackspace/compute_v2"
           Fog::Compute::RackspaceV2.new(attributes)
         end
-      when :digitalocean
-        version = attributes.delete(:version)
-        version = version.to_s.downcase.to_sym unless version.nil?
-        if version == :v1
-          error_message = "DigitalOcean V1 is deprecated.Please use `:version => :v2` attribute to use Next Gen Cloud Servers."
-          raise error_message
-        else
-          require "fog/digitalocean/compute_v2"
-          Fog::Compute::DigitalOceanV2.new(attributes)
-        end
       when :stormondemand
         require "fog/compute/storm_on_demand"
         Fog::Compute::StormOnDemand.new(attributes)

--- a/lib/fog/core/version.rb
+++ b/lib/fog/core/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Core
-    VERSION = "1.42.1"
+    VERSION = "1.42.0"
   end
 end

--- a/lib/fog/core/version.rb
+++ b/lib/fog/core/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Core
-    VERSION = "1.42.0"
+    VERSION = "1.42.1"
   end
 end


### PR DESCRIPTION
@geemus I have removed version2 of digitalocean to clean up the fog-digitalocean gem. https://github.com/fog/fog-digitalocean/pull/9 has the changes for in the fog-digitalocean gem