### PR TITLE
Add file yml caching to models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
-
 gemspec
 

--- a/fog-core.gemspec
+++ b/fog-core.gemspec
@@ -21,7 +21,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency("builder")
   spec.add_dependency("excon", "~> 0.49")
   spec.add_dependency("formatador", "~> 0.2")
+  spec.add_dependency("xmlrpc") if RUBY_VERSION.to_s >= "2.4"
 
+  spec.add_development_dependency("tins") if RUBY_VERSION.to_s > "2.0"
   spec.add_development_dependency("coveralls")
   spec.add_development_dependency("minitest")
   spec.add_development_dependency("minitest-stub-const")

--- a/lib/fog/core/cache.rb
+++ b/lib/fog/core/cache.rb
@@ -153,9 +153,11 @@ module Fog
     end
 
     def self.sandbox
+      raise CacheDir.new("Must set an explicit sandbox for this cache. Example: 'serviceX-regionY'") unless sandbox_name
+
       @sandbox = if @sandbox_name
                    safe_path(File.expand_path("#{SANDBOX_PREFIX}/#{@sandbox_name}"))
-                 end || (raise CacheDir.new("Must set an explicit sandbox for this cache. Example: 'serviceX-regionY'"))
+                 end
     end
 
     def self.sandbox_name=(name)
@@ -166,11 +168,10 @@ module Fog
       @sandbox_name
     end
 
-
     # The path/namespace where the cache is stored for a specific +model_klass+ and +@service+.
     def self.namespace(model_klass, service)
-      name = File.join(self.sandbox, service.class.to_s, model_klass.to_s)
-      name = safe_path(name)
+      ns = File.join(self.sandbox, service.class.to_s, model_klass.to_s)
+      ns = safe_path(ns)
     end
 
     def self.safe_path(klass)

--- a/lib/fog/core/cache.rb
+++ b/lib/fog/core/cache.rb
@@ -131,6 +131,9 @@ module Fog
         Fog::Logger.warning("Found duplicate items in the cache. Expire all & refresh cache soon.")
       end
 
+      # Fog models created, free memory of cached data used for creation.
+      @memoized = nil
+
       uniq_loaded
     end
 
@@ -145,11 +148,12 @@ module Fog
       FileUtils.rm_rf(namespace(model_klass, service))
     end
 
-    # loads yml cache from path on disk
+    # loads yml cache from path on disk, used
+    # to initialize Fog models.
     def self.load_cache(path)
-      @cache ||= {}
-      return @cache[path] if @cache[path]
-      @cache[path] = YAML.load(File.read(path))
+      @memoized ||= {}
+      return @memoized[path] if @memoized[path]
+      @memoized[path] = YAML.load(File.read(path))
     end
 
     def self.namespace_prefix=(name)

--- a/lib/fog/core/cache.rb
+++ b/lib/fog/core/cache.rb
@@ -1,0 +1,210 @@
+# coding: utf-8
+require "fileutils"
+require "yaml"
+require "tmpdir"
+
+module Fog
+  # A generic cache mechanism for fog resources. This can be for a server, security group, etc.
+  #
+  # Currently this is a on-disk cache using yml files per-model instance, however
+  # there is nothing in the way of extending this to use various other cache
+  # backends.
+  #
+  # == Basic functionality
+  #
+  # set the namespace where this cache will be stored:
+  #
+  # Fog::Cache.sandbox_name = "service-account-foo-region-bar"
+  #
+  # cache to disk:
+  #
+  #   # after dumping, there will be a yml file on disk:
+  #   resouce.cache.dump
+  #
+  #   # you can load cached data in from a different session
+  #   Fog::Cache.load(Fog::Compute::AWS::Server, compute)
+  #
+  #   # you can also expire cache (removes cached data assocaited with the resources of this model associated to the service passed in).
+  #   Fog::Cache.expire_cache!(Fog::Compute::AWS::Server, compute)
+  #
+  # == More detailed flow/usage
+  #
+  # Normally, you would have a bunch of resources you want to cache/reload from disk.
+  # Every fog model has a +cache+ object injected to accomplish this. So in order to cache a server for exmaple
+  # you would do something like this:
+  #
+  #   # note this is necessary in order to segregate usage of cache between various providers regions and accounts.
+  #   # if you are using one account/region/etc only, you still must set it. 'default' will do.
+  #   Fog::Cache.sandbox_name = "prod-emea-eu-west-1"
+  #
+  #   s = security_groups.sample; s.name # => "default"
+  #   s.cache.dump # => 2371
+  #
+  # Now it is on disk:
+  #
+  # shai@adsk-lappy ~   % tree ~/.fog-cache/prod-emea-eu-west-1/
+  #
+  #   /Users/shai/.fog-cache/prod-emea-eu-west-1/
+  #     └── fog_compute_aws_real
+  #       └── fog_compute_aws_securitygroup
+  #        ├── default-90928073d9d5d9b4e7545e88aee7ec4f.yml
+  #
+  # You can do the same with a SecurityGroup, Instances, Elbs, etc.
+  #
+  # Note that when loading cache from disk, you need to pass the appropriate model class, and service associated with it.
+  # +Service+ is passed in is so that the service/connection details can be loaded into the loaded instances so they can be re-queried, etc.
+  # +Model+ is passed in so we can find the cache data associated to that model in the sandbox of cache this session is using:
+  # Will try to load all resources associated to those. If you had 1 yml file, or 100, it would load whatever it could find.
+  # As such, the normal usage of dumping would be do it on a collection:
+  #
+  #   load_balancers.each {|elb| elb.cache.dump }
+  #
+  # In order to load the cache into a different session with nothing but the service set up, use like so:
+  # As mentioned, will load all resources associated to the +model_klass+ and +service+ passed in.
+  #
+  #   instances = Fog::Cache.load(Fog::Compute::AWS::Server, compute)
+  #   instances.first.id # => "i-0569a70ae6f47d229"
+  #
+  # Note that if there is no cache located for the +model+ class and +service+ passed to `Fog::Cache.load`
+  # you will get an exception you can handle (for example, to load the resources for the fisrt time):
+  #
+  #   Fog::Cache.expire_cache!(Fog::Compute::AWS::SecurityGroup, compute)
+  #   # ... now there is no SecurityGroup cache data. So, if you tried to load it, you would get an exception:
+  #
+  #   Fog::Cache.load(Fog::Compute::AWS::SecurityGroup, compute)
+  #     rescue Fog::Cache::CacheNotFound => e
+  #       puts "could not find any cache data for security groups on #{compute}"
+  #       get_resources_and_dump
+  #
+  # == Extending cache backends
+  #
+  # Currently this is on-disk using yml. If need be, this could be extended to other cache backends:
+  #
+  # Find references of yaml in this file, split out to strategy objects/diff backends etc.
+  class Cache
+
+    # cache associated not found
+    class CacheNotFound < StandardError; end
+
+    # cache directory problem
+    class CacheDir < StandardError; end
+
+    # where different caches per +service+ api keys, regions etc, are stored
+    # see the +sandbox=+ method.
+    SANDBOX_PREFIX = "~/.fog-cache"
+
+    # when a resource is used such as `server.cache.dump` the model klass is passed in
+    # so that it can be identified from a different session.
+    attr_reader :model
+
+    # Loads cache associated to the +model_klass+ and +service+ into memory.
+    #
+    # If no cache is found, it will raise an error for handling:
+    #
+    #   rescue Fog::Cache::CacheNotFound
+    #     set_initial_cache
+    #
+    def self.load(model_klass, service)
+      cache_files = Dir.glob("#{namespace(model_klass, service)}/*")
+
+      raise CacheNotFound if cache_files.empty?
+
+      loaded = cache_files.map do |path|
+        model_klass = Object.const_get(load_cache(path)[:model_klass])
+        model_klass.new(load_cache(path)[:attrs])
+      end
+
+      collection_klass = load_cache(cache_files.sample)[:collection_klass] &&
+                         Object.const_get(load_cache(cache_files.sample)[:collection_klass])
+
+      loaded.each do |i|
+        # See https://github.com/fog/fog-aws/issues/354#issuecomment-286789702
+        i.collection = collection_klass.new(:service => service) if collection_klass
+        i.instance_variable_set(:@service, service)
+      end
+
+      # uniqe-ify based on the total of attributes. duplicate cache can exist due to
+      # `model#identity` not being unique. but if all attributes match, they are unique
+      # and shouldn't be loaded again.
+      uniq_loaded = loaded.uniq { |i| i.attributes }
+      if uniq_loaded.size != loaded.size
+        Fog::Logger.warning("Found duplicate items in the cache. Expire all & refresh cache soon.")
+      end
+
+      uniq_loaded
+    end
+
+    # creates on-disk cache of this specific +model_klass+ and +@service+
+    def self.create_namespace(model_klass, service)
+      FileUtils.mkdir_p(self.namespace(model_klass, service))
+    end
+
+    # Expires cache - this does not expire all cache associated.
+    # Instead, this will remove all on-disk cache of this specific +model_klass+ and and +@service+
+    def self.expire_cache!(model_klass, service)
+      FileUtils.rm_rf(namespace(model_klass, service))
+    end
+
+    # loads yml cache from path on disk
+    def self.load_cache(path)
+      @cache ||= {}
+      return @cache[path] if @cache[path]
+      @cache[path] = YAML.load(File.read(path))
+    end
+
+    def self.sandbox
+      @sandbox = if @sandbox_name
+                   safe_path(File.expand_path("#{SANDBOX_PREFIX}/#{@sandbox_name}"))
+                 end || (raise CacheDir.new("Must set an explicit sandbox for this cache. Example: 'serviceX-regionY'"))
+    end
+
+    def self.sandbox_name=(name)
+      @sandbox_name = name
+    end
+
+    def self.sandbox_name
+      @sandbox_name
+    end
+
+
+    # The path/namespace where the cache is stored for a specific +model_klass+ and +@service+.
+    def self.namespace(model_klass, service)
+      name = File.join(self.sandbox, service.class.to_s, model_klass.to_s)
+      name = safe_path(name)
+    end
+
+    def self.safe_path(klass)
+      klass.to_s.gsub("::", "_").downcase
+    end
+
+    def initialize(model)
+      @model = model
+    end
+
+    # Dump a Fog::Model resource. Every fog model/instance now has a +cache+ method/object injected in.
+    # as such you can use the #dump method to save the attributes and metadata of that instance as cache
+    # which can be re-used in some other session.
+    def dump
+      if !File.exist?(self.class.namespace(model.class, model.service))
+        self.class.create_namespace(model.class, model.service)
+      end
+
+      data = { :identity => model.identity,
+                     :model_klass => model.class.to_s,
+                     :collection_klass => model.collection && model.collection.class.to_s,
+                     :attrs => model.attributes }
+
+      File.open(dump_to, "w") { |f| f.write(YAML.dump(data)) }
+    end
+
+    # the location of where to save this fog model/instance to.
+    def dump_to
+      # some fog models have an identity field that is duplicate.
+      # duplicate identities can mean the cache for that already exists.
+      # this means cache duplication is possible.
+      #
+      # see "dumping two models that have duplicate identity" test case.
+      name = "#{self.class.namespace(model.class, model.service)}/#{model.identity}-#{SecureRandom.hex}.yml"
+    end
+  end
+end

--- a/lib/fog/core/collection.rb
+++ b/lib/fog/core/collection.rb
@@ -6,7 +6,6 @@ module Fog
     extend Fog::Attributes::ClassMethods
     include Fog::Attributes::InstanceMethods
     include Fog::Core::DeprecatedConnectionAccessors
-    
 
     attr_reader :service
 

--- a/lib/fog/core/model.rb
+++ b/lib/fog/core/model.rb
@@ -1,4 +1,5 @@
 require "fog/core/deprecated_connection_accessors"
+require "fog/core/cache"
 
 module Fog
   class Model
@@ -18,6 +19,10 @@ module Fog
         @service = attribs[:connection]
       end
       merge_attributes(attribs)
+    end
+
+    def cache
+      Fog::Cache.new(self)
     end
 
     def inspect

--- a/spec/core/cache_spec.rb
+++ b/spec/core/cache_spec.rb
@@ -1,0 +1,117 @@
+require "spec_helper"
+require "securerandom"
+require "tmpdir"
+
+module Fog
+  class SubFogTestModel < Fog::Model
+    identity  :id
+  end
+end
+
+module Fog
+  class SubFogTestService < Fog::Service
+
+    class Mock
+      attr_reader :options
+
+      def initialize(opts = {})
+        @options = opts
+      end
+    end
+  end
+end
+
+describe Fog::Cache do
+  before(:each) do
+    Fog.mock!
+    @service = Fog::SubFogTestService.new
+    Fog::Cache.sandbox_name = "test-dir"
+  end
+
+  it "has a sandbox configurable" do
+    Fog::Cache.sandbox_name = "for-service-user-region-foo"
+    # Expand path does not downcase. case insensitive platform tests.
+    assert_equal Fog::Cache.sandbox.downcase, File.expand_path("~/.fog-cache/for-service-user-region-foo").downcase
+  end
+
+  it "must have a sandbox configurable" do
+    Fog::Cache.sandbox_name = nil
+    assert_raises Fog::Cache::CacheDir do
+      Fog::Cache.load(Fog::SubFogTestModel, @service)
+    end
+  end
+
+  it "can create a namespace" do
+    Fog::Cache.expire_cache!(Fog::SubFogTestModel, @service)
+    assert_equal File.exist?(Fog::Cache.namespace(Fog::SubFogTestModel, @service)), false
+
+    Fog::Cache.create_namespace(Fog::SubFogTestModel, @service)
+    assert_equal File.exist?(Fog::Cache.namespace(Fog::SubFogTestModel, @service)), true
+  end
+
+  it "will raise if no cache data found" do
+    Fog::Cache.expire_cache!(Fog::SubFogTestModel, @service)
+
+    assert_raises Fog::Cache::CacheNotFound do
+      Fog::Cache.load(Fog::SubFogTestModel, @service)
+    end
+  end
+
+  it "can be dumped and reloaded back in" do
+
+    Fog::Cache.expire_cache!(Fog::SubFogTestModel, @service)
+
+    id = SecureRandom.hex
+    a = Fog::SubFogTestModel.new(:id => id, :service => @service)
+
+    assert_equal File.exist?(Fog::Cache.namespace(Fog::SubFogTestModel, @service)), false
+    a.cache.dump
+    assert_equal File.exist?(Fog::Cache.namespace(Fog::SubFogTestModel, @service)), true
+
+    instances = Fog::Cache.load(Fog::SubFogTestModel, @service)
+
+    assert_equal instances.first.id, a.id
+    assert_equal instances.first.class, a.class
+  end
+
+  it "dumping two models that have a duplicate identity" do
+    Fog::Cache.expire_cache!(Fog::SubFogTestModel, @service)
+
+    id = SecureRandom.hex
+
+    # security gruops on aws for eg can have the same identity group name 'default'.
+    # there are no restrictions on `identity` fog attributes to be uniq.
+    a = Fog::SubFogTestModel.new(:id => id, :service => @service, :bar => 'bar')
+    b = Fog::SubFogTestModel.new(:id => id, :service => @service, :foo => 'foo')
+
+    a.cache.dump
+    b.cache.dump
+
+    instances = Fog::Cache.load(Fog::SubFogTestModel, @service)
+
+    assert_equal instances.size, 2
+  end
+
+  it "dumping two models that have a duplicate identity twice" do
+    Fog::Cache.expire_cache!(Fog::SubFogTestModel, @service)
+
+    id = SecureRandom.hex
+
+    # security gruops on aws for eg can have the same identity group name 'default'.
+    # there are no restrictions on `identity` fog attributes to be uniq.
+    a = Fog::SubFogTestModel.new(:id => id, :service => @service, :bar => 'bar')
+    b = Fog::SubFogTestModel.new(:id => id, :service => @service, :foo => 'foo')
+
+    a.cache.dump
+    b.cache.dump
+
+    # and then again, w/out expiring cache
+    a.cache.dump
+    b.cache.dump
+
+    instances = Fog::Cache.load(Fog::SubFogTestModel, @service)
+
+    # unique-ify based on the attributes...
+    assert_equal instances.size, 2
+  end
+end

--- a/spec/core/cache_spec.rb
+++ b/spec/core/cache_spec.rb
@@ -25,17 +25,23 @@ describe Fog::Cache do
   before(:each) do
     Fog.mock!
     @service = Fog::SubFogTestService.new
-    Fog::Cache.sandbox_name = "test-dir"
+    Fog::Cache.namespace_prefix = "test-dir"
   end
 
-  it "has a sandbox configurable" do
-    Fog::Cache.sandbox_name = "for-service-user-region-foo"
+  it "has a namespace_prefix configurable" do
+    Fog::Cache.namespace_prefix = "for-service-user-region-foo"
+
     # Expand path does not downcase. case insensitive platform tests.
-    assert_equal Fog::Cache.sandbox.downcase, File.expand_path("~/.fog-cache/for-service-user-region-foo").downcase
+    example_cache = File.expand_path(Fog::Cache.namespace(Fog::SubFogTestModel, @service)).downcase
+    expected_namespace = File.expand_path("~/.fog-cache/for-service-user-region-foo").downcase
+
+    puts example_cache
+    puts expected_namespace
+    assert_equal example_cache.include?(expected_namespace), true
   end
 
-  it "must have a sandbox configurable" do
-    Fog::Cache.sandbox_name = nil
+  it "must have a namespace_prefix configurable" do
+    Fog::Cache.namespace_prefix = nil
     assert_raises Fog::Cache::CacheDir do
       Fog::Cache.load(Fog::SubFogTestModel, @service)
     end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -174,6 +174,7 @@ describe Fog::Service do
     it "ignores the global and its values" do
       @config = MiniTest::Mock.new
       def @config.config_service?;  true; end
+      def @config.nil?; false; end
       def @config.==(other); object_id == other.object_id; end
 
       unexpected_usage = lambda { raise "Accessing global!" }


### PR DESCRIPTION
Hey @geemus regarding the caching issue @ https://github.com/fog/fog-aws/issues/354#issuecomment-286789702

To take care of before merging:

- [x] How to safely assume a service identifier? Currently using region just as a placeholder.
- [x] Add downcase for case insensitive platforms.
- [x] Documentation on public methods.
- [x] Ruby not use /tmp tmpdir change.
- [x] Other feedback.

Works with a test CLI application using this fork. You can see usage in the test file, the gist is:

- Expiring cache:
```
[1] pry> Fog::Cache.expire_cache!(Fog::Compute::AWS::Server, compute)
=> ["/tmp/Fog_Compute_AWS_Real/us-east-1/Fog_Compute_AWS_Server"]
```

- Raises on empty cache:
```
[2] pry> ss = Fog::Cache.load(Fog::Compute::AWS::Server, compute)
Fog::Cache::CacheNotFound: Fog::Cache::CacheNotFound
from /Users/shai/r/fog-core/lib/fog/core/cache.rb:15:in `load'
```

- Dumping an instance:
```
[1] pry> s = c.servers.sample; s.id
=> "i-0569a70ae6f47d229"
[2] pry> s.cache.dump
=> 2371
```

- On disk:
```
shai@adsk-lappy ~   % tree /tmp/Fog_Compute_AWS_Real/us-east-1/Fog_Compute_AWS_Server/
/tmp/Fog_Compute_AWS_Real/us-east-1/Fog_Compute_AWS_Server/
└── i-0569a70ae6f47d229.yml
```

- Loading cache in different session:
```
# Not sure if there's a way to determine model class from collection class then
# this call would read nicer (returns collection since we don't have identifiers, just globbing).

[1] pry> instances = Fog::Cache.load(Fog::Compute::AWS::Server, compute)
...
[2] pry> instances.first.id
=> "i-0569a70ae6f47d229"
```