### PR TITLE
Add exponential increase on timeout in #sshable? for services that do not respond in 8s

### DIFF
--- a/fog-core.gemspec
+++ b/fog-core.gemspec
@@ -2,6 +2,7 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "fog/core/version"
+require 'english'
 
 Gem::Specification.new do |spec|
   spec.name          = "fog-core"

--- a/fog-core.gemspec
+++ b/fog-core.gemspec
@@ -2,7 +2,6 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "fog/core/version"
-require 'english'
 
 Gem::Specification.new do |spec|
   spec.name          = "fog-core"

--- a/lib/fog/compute/models/server.rb
+++ b/lib/fog/compute/models/server.rb
@@ -102,6 +102,14 @@ module Fog
         false
       end
 
+      # Is the server ready to receive connections?
+      #
+      # Returns default.
+      #
+      # Subclasses should implement #ready? appropriately.
+      def ready?
+        false
+      end
 
       private
 

--- a/lib/fog/compute/models/server.rb
+++ b/lib/fog/compute/models/server.rb
@@ -3,6 +3,8 @@ require "fog/core/model"
 module Fog
   module Compute
     class Server < Fog::Model
+      INITIAL_SSHABLE_TIMEOUT = 8
+
       attr_writer :username, :private_key, :private_key_path, :public_key, :public_key_path, :ssh_port, :ssh_options
       # Sets the proc used to determine the IP Address used for ssh/scp interactions.
       # @example
@@ -87,9 +89,26 @@ module Fog
       end
 
       def sshable?(options = {})
-        ready? && !ssh_ip_address.nil? && !!Timeout.timeout(8) { ssh("pwd", options) }
+        result = ready? && !ssh_ip_address.nil? && !!Timeout.timeout(sshable_timeout) { ssh("pwd", options) }
+        @sshable_timeout = nil
+        result
       rescue SystemCallError, Net::SSH::AuthenticationFailed, Net::SSH::Disconnect, Timeout::Error
         false
+      end
+
+
+      private
+
+      def sshable_timeout
+        if @sshable_timeout
+          if @sshable_timeout >= 40
+            @sshable_timeout = 60
+          else
+            @sshable_timeout *= 1.5
+          end
+        else
+          @sshable_timeout = INITIAL_SSHABLE_TIMEOUT
+        end
       end
     end
   end

--- a/spec/compute/models/server_spec.rb
+++ b/spec/compute/models/server_spec.rb
@@ -1,0 +1,114 @@
+require "spec_helper"
+require "fog/compute/models/server"
+
+describe Fog::Compute::Server do
+  before do
+    @server = Fog::Compute::Server.new
+  end
+
+  describe "#sshable?" do
+    before do
+      # I'm not sure why #sshable? depends on a method that's not defined except in implementing classes
+      def @server.ready?;end
+    end
+
+    describe "when the server is not ready" do
+      it "is false" do
+        @server.stub(:ready?, false) do
+          assert @server.sshable? == false
+        end
+      end
+    end
+
+    describe "when the server is ready" do
+      describe "when the ssh_ip_address is nil" do
+        it "is false" do
+          @server.stub(:ready?, true) do
+            @server.stub(:ssh_ip_address, nil) do
+              assert @server.sshable? == false
+            end
+          end
+        end
+      end
+
+
+      describe "when the ssh_ip_address exists" do
+        # Define these constants which would be imported by net-ssh once loaded
+        module Net
+          module SSH
+            class AuthenticationFailed  < RuntimeError
+            end
+            class Disconnect < RuntimeError
+            end
+          end
+        end
+
+        describe "and ssh times out" do
+          it "is false" do
+            @server.stub(:ready?, true) do
+              @server.stub(:ssh_ip_address, "10.0.0.1") do
+                raises_timeout = -> (_time) { raise Timeout::Error.new }
+                Timeout.stub(:timeout, raises_timeout) do
+                  assert @server.sshable? == false
+                end
+              end
+            end
+          end
+        end
+
+        describe "and it raises Net::SSH::AuthenticationFailed" do
+          it "is false" do
+            @server.stub(:ready?, true) do
+              @server.stub(:ssh_ip_address, "10.0.0.1") do
+                raises_timeout = -> (_cmd, _options) { raise Net::SSH::AuthenticationFailed.new }
+                @server.stub(:ssh, raises_timeout) do
+                  assert @server.sshable? == false
+                end
+              end
+            end
+          end
+        end
+
+        describe "and it raises Net::SSH::Disconnect" do
+          it "is false" do
+            @server.stub(:ready?, true) do
+              @server.stub(:ssh_ip_address, "10.0.0.1") do
+                raises_timeout = -> (_cmd, _options) { raise Net::SSH::Disconnect.new }
+                @server.stub(:ssh, raises_timeout) do
+                  assert @server.sshable? == false
+                end
+              end
+            end
+          end
+        end
+
+        describe "and it raises SystemCallError" do
+          it "is false" do
+            @server.stub(:ready?, true) do
+              @server.stub(:ssh_ip_address, "10.0.0.1") do
+                raises_timeout = -> (_cmd, _options) { raise SystemCallError.new("message, 0") }
+                @server.stub(:ssh, raises_timeout) do
+                  assert @server.sshable? == false
+                end
+              end
+            end
+          end
+        end
+
+        describe "and ssh completes within the designated timeout" do
+          it "is true" do
+            @server.stub(:ready?, true) do
+              @server.stub(:ssh_ip_address, "10.0.0.1") do
+                @server.stub(:ssh, "datum") do
+                  assert @server.sshable? == true
+                end
+              end
+            end
+          end
+        end
+
+      end
+    end
+
+  end
+end

--- a/spec/compute/models/server_spec.rb
+++ b/spec/compute/models/server_spec.rb
@@ -7,11 +7,6 @@ describe Fog::Compute::Server do
   end
 
   describe "#sshable?" do
-    before do
-      # I'm not sure why #sshable? depends on a method that's not defined except in implementing classes
-      def @server.ready?;end
-    end
-
     describe "when the server is not ready" do
       it "is false" do
         @server.stub(:ready?, false) do

--- a/spec/compute/models/server_spec.rb
+++ b/spec/compute/models/server_spec.rb
@@ -60,9 +60,22 @@ describe Fog::Compute::Server do
           it "is false" do
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raises_timeout = lambda { |_cmd, _options| raise Net::SSH::AuthenticationFailed.new }
-                @server.stub(:ssh, raises_timeout) do
+                raise_error = lambda { |_cmd, _options| raise Net::SSH::AuthenticationFailed.new }
+                @server.stub(:ssh, raise_error) do
                   refute @server.sshable?
+                end
+              end
+            end
+          end
+
+          it "resets SSH timeout" do
+            @server.instance_variable_set(:@sshable_timeout, 8)
+            @server.stub(:ready?, true) do
+              @server.stub(:ssh_ip_address, "10.0.0.1") do
+                raise_error = lambda { |_cmd, _options| raise Net::SSH::AuthenticationFailed.new }
+                @server.stub(:ssh, raise_error) do
+                  @server.sshable?
+                  assert_nil @server.instance_variable_get(:@sshable_timeout), nil
                 end
               end
             end
@@ -73,9 +86,22 @@ describe Fog::Compute::Server do
           it "is false" do
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raises_timeout = lambda { |_cmd, _options| raise Net::SSH::Disconnect.new }
-                @server.stub(:ssh, raises_timeout) do
+                raise_error = lambda { |_cmd, _options| raise Net::SSH::Disconnect.new }
+                @server.stub(:ssh, raise_error) do
                   refute @server.sshable?
+                end
+              end
+            end
+          end
+
+          it "resets SSH timeout" do
+            @server.instance_variable_set(:@sshable_timeout, 8)
+            @server.stub(:ready?, true) do
+              @server.stub(:ssh_ip_address, "10.0.0.1") do
+                raise_error = lambda { |_cmd, _options| raise Net::SSH::Disconnect.new }
+                @server.stub(:ssh, raise_error) do
+                  @server.sshable?
+                  assert_nil @server.instance_variable_get(:@sshable_timeout), nil
                 end
               end
             end
@@ -86,9 +112,21 @@ describe Fog::Compute::Server do
           it "is false" do
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raises_timeout = lambda { |_cmd, _options| raise SystemCallError.new("message, 0") }
-                @server.stub(:ssh, raises_timeout) do
+                raise_error = lambda { |_cmd, _options| raise SystemCallError.new("message, 0") }
+                @server.stub(:ssh, raise_error) do
                   refute @server.sshable?
+                end
+              end
+            end
+          end
+
+          it "does not increase SSH timeout" do
+            @server.stub(:ready?, true) do
+              @server.stub(:ssh_ip_address, "10.0.0.1") do
+                raise_error = lambda { |_cmd, _options| raise SystemCallError.new("message, 0") }
+                @server.stub(:ssh, raise_error) do
+                  @server.sshable?
+                  assert_equal @server.instance_variable_get(:@sshable_timeout), 8
                 end
               end
             end

--- a/spec/compute/models/server_spec.rb
+++ b/spec/compute/models/server_spec.rb
@@ -47,7 +47,7 @@ describe Fog::Compute::Server do
           it "is false" do
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raises_timeout = -> (_time) { raise Timeout::Error.new }
+                raises_timeout = lambda { |_time| raise Timeout::Error.new }
                 Timeout.stub(:timeout, raises_timeout) do
                   refute @server.sshable?
                 end
@@ -60,7 +60,7 @@ describe Fog::Compute::Server do
           it "is false" do
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raises_timeout = -> (_cmd, _options) { raise Net::SSH::AuthenticationFailed.new }
+                raises_timeout = lambda { |_cmd, _options| raise Net::SSH::AuthenticationFailed.new }
                 @server.stub(:ssh, raises_timeout) do
                   refute @server.sshable?
                 end
@@ -73,7 +73,7 @@ describe Fog::Compute::Server do
           it "is false" do
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raises_timeout = -> (_cmd, _options) { raise Net::SSH::Disconnect.new }
+                raises_timeout = lambda { |_cmd, _options| raise Net::SSH::Disconnect.new }
                 @server.stub(:ssh, raises_timeout) do
                   refute @server.sshable?
                 end
@@ -86,7 +86,7 @@ describe Fog::Compute::Server do
           it "is false" do
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raises_timeout = -> (_cmd, _options) { raise SystemCallError.new("message, 0") }
+                raises_timeout = lambda { |_cmd, _options| raise SystemCallError.new("message, 0") }
                 @server.stub(:ssh, raises_timeout) do
                   refute @server.sshable?
                 end
@@ -112,15 +112,17 @@ describe Fog::Compute::Server do
             it "increases the timeout factor by 1.5" do
               @server.stub(:ready?, true) do
                 @server.stub(:ssh_ip_address, "10.0.0.1") do
-                  raises_timeout = -> (time) do
-                    assert(time == 8); raise Timeout::Error.new
+                  raises_timeout = lambda do |time|
+                    assert(time == 8)
+                    raise Timeout::Error.new
                   end
                   Timeout.stub(:timeout, raises_timeout) do
                     refute @server.sshable?
                   end
 
-                  raises_timeout = -> (time) do
-                    assert_equal(12, time); raise Timeout::Error.new
+                  raises_timeout = lambda do |time|
+                    assert_equal(12, time)
+                    raise Timeout::Error.new
                   end
                   Timeout.stub(:timeout, raises_timeout) do
                     refute @server.sshable?
@@ -132,20 +134,22 @@ describe Fog::Compute::Server do
             it "does not increase timeout beyond 60s" do
               @server.stub(:ready?, true) do
                 @server.stub(:ssh_ip_address, "10.0.0.1") do
-                  raises_timeout = -> (_time) { raise Timeout::Error.new }
+                  raises_timeout = lambda { |_time| raise Timeout::Error.new }
                   Timeout.stub(:timeout, raises_timeout) do
                     5.times { refute @server.sshable? }
                   end
 
-                  raises_timeout = -> (time) do
-                    assert_equal(60, time); raise Timeout::Error.new
+                  raises_timeout = lambda do |time|
+                    assert_equal(60, time)
+                    raise Timeout::Error.new
                   end
                   Timeout.stub(:timeout, raises_timeout) do
                     refute @server.sshable?
                   end
 
-                  raises_timeout = -> (time) do
-                    assert_equal(60, time); raise Timeout::Error.new
+                  raises_timeout = lambda do |time|
+                    assert_equal(60, time)
+                    raise Timeout::Error.new
                   end
                   Timeout.stub(:timeout, raises_timeout) do
                     refute @server.sshable?
@@ -158,8 +162,9 @@ describe Fog::Compute::Server do
               it "resets the timeout to the initial value" do
                 @server.stub(:ready?, true) do
                   @server.stub(:ssh_ip_address, "10.0.0.1") do
-                    raises_timeout = -> (time) do
-                      assert(time == 8); raise Timeout::Error.new
+                    raises_timeout = lambda do |time|
+                      assert(time == 8)
+                      raise Timeout::Error.new
                     end
                     Timeout.stub(:timeout, raises_timeout) do
                       refute @server.sshable?
@@ -169,8 +174,9 @@ describe Fog::Compute::Server do
                       assert @server.sshable?
                     end
 
-                    raises_timeout = -> (time) do
-                      assert_equal(8, time); raise Timeout::Error.new
+                    raises_timeout = lambda do |time|
+                      assert_equal(8, time)
+                      raise Timeout::Error.new
                     end
                     Timeout.stub(:timeout, raises_timeout) do
                       refute @server.sshable?

--- a/spec/core/cache_spec.rb
+++ b/spec/core/cache_spec.rb
@@ -49,7 +49,7 @@ describe Fog::Cache do
 
     # diff namespace, diff metadata
     Fog::Cache.namespace_prefix = "different-namespace"
-    assert_equal Fog::Cache.metadata[:last_dumped], nil
+    assert_nil Fog::Cache.metadata[:last_dumped]
     # still accessible per namespace
     Fog::Cache.namespace_prefix = "for-service-user-region-foo"
     assert_equal Fog::Cache.metadata[:last_dumped],  "Tuesday, November 8, 2016"

--- a/spec/fog_attribute_spec.rb
+++ b/spec/fog_attribute_spec.rb
@@ -231,7 +231,7 @@ describe "Fog::Attributes" do
 
   describe ":default => 'default_value'" do
     it "should return nil when default is not defined on a new object" do
-      assert_equal model.bool, nil
+      assert_nil model.bool
     end
 
     it "should return the value of the object when default is not defined" do
@@ -259,18 +259,18 @@ describe "Fog::Attributes" do
 
     it "should return nil on a persisted object without a value" do
       model.merge_attributes(:id => "some-crazy-id")
-      assert_equal model.default, nil
+      assert_nil model.default
     end
 
     it "should return nil when an attribute with default value is setted to nil" do
       model.default = nil
-      assert_equal model.default, nil
+      assert_nil model.default
     end
   end
 
   describe ".has_one" do
     it "should create an instance_variable to save the association object" do
-      assert_equal model.one_object, nil
+      assert_nil model.one_object
     end
 
     it "should create a getter to save the association model" do
@@ -292,7 +292,7 @@ describe "Fog::Attributes" do
 
   describe ".has_one_identity" do
     it "should create an instance_variable to save the association identity" do
-      assert_equal model.one_identity, nil
+      assert_nil model.one_identity
     end
 
     it "should create a getter to load the association model" do


### PR DESCRIPTION
See issue fog/fog-aws#372

For AWS Spot Request, instances never complete the `#setup` process eventually timing out through the `#wait_for` block because the default 8s is apparently not long enough to get the ssh connection. Through testing 11s seemed to work, but this is likely highly variable for regions, instance types, images, and providers.

This change implements a 1.5 increase in timeout each time `#sshable?` is called, capped at 60s. If a successful connection is made, then the timeout is reset to the initial value.

I tried to keep this as simple as possible. This solves the problem for AWS Spot Requets and does not adversely affect regular AWS instances. I have not tested this with other providers, but a quick check it didn't seem like this would be a problem.

The only concern I have is that there's no way to reset the `@sshable_timeout` value, but I don't see an instance where `sshable?` would be called successively on an instance, would continue to fail, and then you'd want to call it on that instance again, but starting at the lower timeout.

One other question is whether it's appropriate to increase the timeout for all failures, or if we should only increase the timeout with a `Timeout::Error`.

---
Note that there were no specs for `Fog::Compute::Server`, so I implemented specs for the existing behavior of `#sshable?` (leaving the specs of the remaining methods to others to complete coverage).

I'm happy to squash commits, but for readability, I thought it would help to see the separation of the two parts.