### PR TITLE
Drop Ruby<2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 
 rvm:
+  - 2.0
   - 2.1
   - 2.2
   - 2.3
@@ -15,14 +16,6 @@ script: bundle exec rake travis
 matrix:
   fast_finish: true
   include:
-    - rvm: 1.8.7
-      gemfile: Gemfile.1.8.7
-    - rvm: jruby-18mode
-      gemfile: Gemfile.1.8.7
-    - rvm: 1.9.3
-      gemfile: Gemfile.1.9.3
-    - rvm: jruby-19mode
-      gemfile: Gemfile.1.9.3
     - rvm: 2.1
       gemfile: Gemfile
       env: COVERAGE=true

--- a/Gemfile.1.8.7
+++ b/Gemfile.1.8.7
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec
-
-gem 'rake', '~> 10.1.1'

--- a/Gemfile.1.9.3
+++ b/Gemfile.1.9.3
@@ -1,9 +1,0 @@
-source "https://rubygems.org"
-
-gemspec
-
-gem 'net-ssh', '< 3.0'
-gem 'rubocop', '~> 0.41.2'
-gem 'term-ansicolor', '~> 1.3.2'
-gem 'tins', '~> 1.6.0'
-gem 'mime-types', '< 3.0'

--- a/README.md
+++ b/README.md
@@ -25,17 +25,6 @@ Or install it yourself as:
 
     $ gem install fog-core
 
-### Ruby 1.9.3
-
-Some of `fog-core`'s dependencies have dropped support for Ruby 1.9.3 in later
-versions. Rather than limit all `fog` users to older but compatible versions,
-if you are using 1.9.3 you will need to declare a compatible version in your
-application's `Gemfile` like:
-
-    gem "net-ssh", "< 3.0"
-
-See `Gemfile.1.9.3` for the definitive list as tested by Travis.
-
 ## Usage
 
 TODO: Write usage instructions here

--- a/fog-core.gemspec
+++ b/fog-core.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.0.0'
+
   spec.add_dependency("builder")
   spec.add_dependency("excon", "~> 0.58")
   spec.add_dependency("formatador", "~> 0.2")
@@ -31,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("minitest-stub-const")
   spec.add_development_dependency("pry")
   spec.add_development_dependency("rake")
-  spec.add_development_dependency("rubocop") if RUBY_VERSION.to_s >= "1.9.3"
+  spec.add_development_dependency("rubocop")
   spec.add_development_dependency("thor")
   spec.add_development_dependency("yard")
 end

--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -36,13 +36,8 @@ module Fog
       Fog.const_get(provider_name).const_get(*const_get_args(service_name))
     end
 
-    # Ruby 1.8 does not support the second 'inherit' argument to #const_get
     def const_get_args(*args)
-      if RUBY_VERSION < '1.9'
-        args
-      else
-        args + [false]
-      end
+      args + [false]
     end
 
     def service_name

--- a/lib/fog/test_helpers/collection_helper.rb
+++ b/lib/fog/test_helpers/collection_helper.rb
@@ -33,12 +33,6 @@ def collection_tests(collection, params = {}, mocks_implemented = true)
       methods = %w(all? any? find detect collect map find_index flat_map
                    collect_concat group_by none? one?)
 
-      # JRuby 1.7.5+ issue causes a SystemStackError: stack level too deep
-      # https://github.com/jruby/jruby/issues/1265
-      if RUBY_PLATFORM == "java" && JRUBY_VERSION =~ /1\.7\.[5-8]/
-        methods.delete("all?")
-      end
-
       methods.each do |enum_method|
         next unless collection.respond_to?(enum_method)
         tests("##{enum_method}").succeeds do

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -96,15 +96,10 @@ describe "Fog::Storage" do
 
   describe ".get_body_size" do
     it "doesn't alter the encoding of the string passed to it" do
-      # Ruby 1.8 doesn't support string encodings, so we can't test that
-      if RUBY_VERSION >= "1.9.3"
-        body = "foo".encode("UTF-8")
-        Fog::Storage.get_body_size(body)
+      body = "foo".encode("UTF-8")
+      Fog::Storage.get_body_size(body)
 
-        assert_equal("UTF-8", body.encoding.to_s)
-      else
-        skip
-      end
+      assert_equal("UTF-8", body.encoding.to_s)
     end
 
     it "respects frozen strings" do


### PR DESCRIPTION
According to README, fog-core does not support Ruby 1.9. Users
requiring it should use the fog gem.