### PR TITLE
Add missing runtime dependency declaration to gemspec

### DIFF
--- a/fog-core.gemspec
+++ b/fog-core.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency("builder")
+  spec.add_dependency("mime-types")
   spec.add_dependency("excon", "~> 0.58")
   spec.add_dependency("formatador", "~> 0.2")
 

--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -1,20 +1,15 @@
+begin
+  # Use mime/types/columnar if available, for reduced memory usage
+  require 'mime/types/columnar'
+rescue LoadError
+  require 'mime/types'
+end
+
 module Fog
   module Storage
     extend Fog::ServicesMixin
 
     def self.new(orig_attributes)
-      begin
-        # Use mime/types/columnar if available, for reduced memory usage
-        require 'mime/types/columnar'
-      rescue LoadError
-        begin
-          require 'mime/types'
-        rescue LoadError
-          Fog::Logger.warning("'mime-types' missing, please install and try again.")
-          raise
-        end
-      end
-
       attributes = orig_attributes.dup # prevent delete from having side effects
       case attributes.delete(:provider).to_s.downcase.to_sym
       when :internetarchive


### PR DESCRIPTION
This adds mime-types as runtime dependency into gemspec, which is required in https://github.com/fog/fog-core/blob/master/lib/fog/storage.rb

It wasn't added before because of fog's support of Ruby 1.9.3. 
Support for Ruby 1.9.3 was removed from fog in https://github.com/fog/fog/pull/3974
