### PR TITLE
Fix warning: key :libvirt_uri is duplicated

### DIFF
--- a/lib/fog/test_helpers/mock_helper.rb
+++ b/lib/fog/test_helpers/mock_helper.rb
@@ -66,7 +66,6 @@ if Fog.mock?
     :ovirt_url                        => "http://ovirt:8080/api",
     :ovirt_username                   => "admin@internal",
     :ovirt_password                   => "123123",
-    :libvirt_uri                      => "qemu://libvirt/system",
     :rackspace_api_key                => "rackspace_api_key",
     :rackspace_username               => "rackspace_username",
     :riakcs_access_key_id             => "riakcs_access_key_id",


### PR DESCRIPTION
```
/lib/fog/test_helpers/mock_helper.rb:69: warning: key :libvirt_uri is duplicated and overwritten on line 91
```