### PR TITLE
fix nil fetch on object reload

### DIFF
--- a/lib/fog/core/model.rb
+++ b/lib/fog/core/model.rb
@@ -46,6 +46,8 @@ module Fog
 
       object = collection.get(identity)
 
+      return unless object
+
       merge_attributes(object.all_associations_and_attributes)
 
       self


### PR DESCRIPTION
There is no guarantee that `collection.get` will return an object and the `nil` case should be handled appropriately.