### PR TITLE
Fixup typo otps -> opts (2.1.1 error)

### DIFF
--- a/lib/fog/core/ssh.rb
+++ b/lib/fog/core/ssh.rb
@@ -118,7 +118,7 @@ module Fog
         # https://github.com/net-ssh/net-ssh/pull/524
         opts = { :paranoid => false, :verify_host_key => false }.merge(options)
         if Net::SSH::VALID_OPTIONS.include? :verify_host_key
-          otps.delete(:paranoid)
+          opts.delete(:paranoid)
         end
         opts
       end


### PR DESCRIPTION
```
Traceback (most recent call last):
	6: from check_dqa_vm.rb:81:in `<main>'
	5: from /usr/local/bundle/gems/fog-core-2.1.1/lib/fog/compute/models/server.rb:88:in `ssh'
	4: from /usr/local/bundle/gems/fog-core-2.1.1/lib/fog/core/ssh.rb:9:in `new'
	3: from /usr/local/bundle/gems/fog-core-2.1.1/lib/fog/core/ssh.rb:9:in `new'
	2: from /usr/local/bundle/gems/fog-core-2.1.1/lib/fog/core/ssh.rb:40:in `initialize'
	1: from /usr/local/bundle/gems/fog-core-2.1.1/lib/fog/core/ssh.rb:104:in `build_options'
/usr/local/bundle/gems/fog-core-2.1.1/lib/fog/core/ssh.rb:121:in `merge_default_options_into': undefined local variable or method `otps' for #<Fog::SSH::Real:0x000055da87f1eb60> (NameError)
Did you mean?  opts
```