### PR TITLE
Do not force number option values as numbers - fix for OVH OpenStack

### DIFF
--- a/lib/fog/core/service.rb
+++ b/lib/fog/core/service.rb
@@ -163,8 +163,6 @@ module Fog
           value_string = value.to_s.downcase
           if value.nil?
             options.delete(key)
-          elsif value_string.to_i.to_s == value
-            options[key] = value.to_i
           else
             options[key] = case value_string
                            when "false"

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -58,10 +58,16 @@ describe Fog::Service do
       refute_includes service.options.keys, :generic_user
     end
 
-    it "converts number String values with to_i" do
+    it "handles number String as numbers" do
       service = TestService.new :generic_api_key => "3421"
+      assert_equal "3421", service.options[:generic_api_key]
+    end
+
+    it "handles number as number" do
+      service = TestService.new :generic_api_key => 3421
       assert_equal 3421, service.options[:generic_api_key]
     end
+
 
     it "converts 'true' String values to TrueClass" do
       service = TestService.new :generic_api_key => "true"


### PR DESCRIPTION
This fixes OVH openstack support.

In OVH tennant / project name is a number. When option is converted into number we get error:
```
{"error": {"message": "object of type 'int' has no len()", "code": 400, "title": "Bad Request"}}
```
I think, that fog should not enforce variable types. When user specifies something as string - it should be handled string.