### PR TITLE
Log issues when loading providers

### DIFF
--- a/lib/fog/core/services_mixin.rb
+++ b/lib/fog/core/services_mixin.rb
@@ -27,7 +27,9 @@ module Fog
       require_service_provider_library(service_name.downcase, provider)
       spc = service_provider_constant(service_name, provider_name)
       spc.new(attributes)
-    rescue LoadError, NameError  # Only rescue errors in finding the libraries, allow connection errors through to the caller
+    rescue LoadError, NameError => e  # Only rescue errors in finding the libraries, allow connection errors through to the caller
+      Fog::Logger.warning("Error while loading provider #{provider}: #{e.message}")
+      Fog::Logger.debug("backtrace: #{e.backtrace.join("\n")}")
       raise Fog::Service::NotFound, "#{provider} has no #{service_name.downcase} service"
     end
 


### PR DESCRIPTION
I was hitting issue Fog::Service::NotFound: ovirt has no compute service
when trying to use fog-ovirt and there was no indication of what could be
wrong. Eventually, I've figured out, that there was issue with
dependencies inside fog-ovirt, that we were suppressing.

This patch adds logging around the requiring the provider so that this
issues are easier to debug later.

There are several issues in the past around the 'no compute service' that would benefit from more logging,
such as:

- https://github.com/fog/fog-xenserver/issues/60
- https://github.com/fog/fog-google/issues/170
- https://github.com/fog/fog-openstack/issues/181
- https://github.com/mitchellh/vagrant-aws/issues/505