### PR TITLE
Use :never in ssh/scp verify_host_key option

### DIFF
--- a/lib/fog/core/scp.rb
+++ b/lib/fog/core/scp.rb
@@ -64,8 +64,9 @@ module Fog
 
         @address  = address
         @username = username
-        @options  = { :paranoid => false, :verify_host_key => false }.merge(options)
+        @options  = { :paranoid => false, :verify_host_key => :never }.merge(options)
         @options.delete(:paranoid) if Net::SSH::VALID_OPTIONS.include? :verify_host_key
+        @options[:verify_host_key] = false unless Net::SSH::Verifiers.const_defined?(:Never)
       end
 
       def upload(local_path, remote_path, upload_options = {}, &block)

--- a/lib/fog/core/ssh.rb
+++ b/lib/fog/core/ssh.rb
@@ -116,10 +116,11 @@ module Fog
 
         # net-ssh has deprecated :paranoid in favor of :verify_host_key
         # https://github.com/net-ssh/net-ssh/pull/524
-        opts = { :paranoid => false, :verify_host_key => false }.merge(options)
+        opts = { :paranoid => false, :verify_host_key => :never }.merge(options)
         if Net::SSH::VALID_OPTIONS.include? :verify_host_key
           opts.delete(:paranoid)
         end
+        opts[:verify_host_key] = false unless Net::SSH::Verifiers.const_defined?(:Never)
         opts
       end
 


### PR DESCRIPTION
Fix #251 