### PR TITLE
Auto coerce name key in config into string

### DIFF
--- a/lib/fog/core/service.rb
+++ b/lib/fog/core/service.rb
@@ -163,6 +163,8 @@ module Fog
           value_string = value.to_s.downcase
           if value.nil?
             options.delete(key)
+         elsif key.end_with? 'name'
+            options[key] = value.to_s
           elsif value_string.to_i.to_s == value
             options[key] = value.to_i
           else


### PR DESCRIPTION
Currently if the name of the project is like a number like `123` for example,  passing `"123"` as `openstack_project_name` option will not return an error from the remote OpenStack server.
Because it is auto coerced into `integer` and not `string`.

This patch forces `openstack_project_name` and alike params to be string.