### PR TITLE
feat(Provider): Underscore name

### DIFF
--- a/lib/fog/core/provider.rb
+++ b/lib/fog/core/provider.rb
@@ -11,6 +11,7 @@ module Fog
     def self.extended(base)
       provider = base.to_s.split("::").last
       Fog.providers[provider.downcase.to_sym] = provider
+      Fog.providers[underscore_name(provider)] = provider
     end
 
     def [](service_key)
@@ -45,6 +46,16 @@ module Fog
         )
       )
       ['Fog', constant_string, provider].join("::")
+    end
+
+    private
+
+    def underscore_name(string)
+      string.gsub(/::/, '/').
+        gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+        gsub(/([a-z\d])([A-Z])/,'\1_\2').
+        tr("-", "_").
+        downcase
     end
   end
 end


### PR DESCRIPTION
I'm not sure about having two keys for the same provider here so i'm open this to start a discussion about the actual problem.

It all started with fog/fog-internet-archive#2 where `shindot` could not load some files.

When we started extracting providers we gave them proper names like:

- `bare_metal_cloud` over `baremetalcloud`
- `go_grid` over `gogrid`
- `internet_archive` over `internetarchive`
- `storm_on_demand` over `stormondemand`
- `vcloud_director` over `vclouddirector`

The problem lies in [here](https://github.com/fog/fog-core/blob/567982afac90edfd880e5b38c584062302224dcc/lib/fog/core/provider.rb#L11-L14):

```ruby
def self.extended(base)
  provider = base.to_s.split("::").last
  Fog.providers[provider.downcase.to_sym] = provider
end
```

This code generates keys based on the class name. It just downcases it like:

- `Fog::BareMetalCloud` becomes `:baremetalcloud`
- `Fog::GoGrid` becomes `:gogrid`
- `Fog::InternetArchive` becomes `:internetarchive`
- `Fog::StormOnDemand` becomes `:stormondemand`
- `Fog::VcloudDirector` becomes `:vclouddirector`

Since we are deprecating this style generated by this code in [here](https://github.com/fog/fog-core/blob/567982afac90edfd880e5b38c584062302224dcc/lib/fog/core/services_mixin.rb#L74-L96):

```ruby
def check_provider_alias(provider)
  case provider
  when :baremetalcloud
    Fog::Logger.deprecation(':baremetalcloud is deprecated. Use :bare_metal_cloud instead!')
    :bare_metal_cloud
  when :gogrid
    Fog::Logger.deprecation(':gogrid is deprecated. Use :go_grid instead!')
    :go_grid
  when :internetarchive
    Fog::Logger.deprecation(':internetarchive is deprecated. Use :internet_archive instead!')
    :internet_archive
  when :new_servers
    Fog::Logger.deprecation(':new_servers is deprecated. Use :bare_metal_cloud instead!')
    :bare_metal_cloud
  when :stormondemand
    Fog::Logger.deprecation(':stormondemand is deprecated. Use :storm_on_demand instead!')
    :storm_on_demand
  when :vclouddirector
    Fog::Logger.deprecation(':vclouddirector is deprecated. Use :vcloud_director instead!')
    :vcloud_director
  else provider
  end
end
```

My first option was to setup the key to be the expected one but since we might break a lot of stuff that relies on this `old` key, my second option was to maintain both options since the old one is already deprecated.

cc/ @geemus @icco 

WDYT?