### PR TITLE
Fix Call to `#underscore_name`

### DIFF
--- a/lib/fog/core/provider.rb
+++ b/lib/fog/core/provider.rb
@@ -8,10 +8,22 @@ module Fog
   end
 
   module Provider
-    def self.extended(base)
-      provider = base.to_s.split("::").last
-      Fog.providers[provider.downcase.to_sym] = provider
-      Fog.providers[underscore_name(provider)] = provider
+    class << self
+      def extended(base)
+        provider = base.to_s.split("::").last
+        Fog.providers[provider.downcase.to_sym] = provider
+        Fog.providers[underscore_name(provider)] = provider
+      end
+    
+      private
+
+      def underscore_name(string)
+        string.gsub(/::/, '/').
+          gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+          gsub(/([a-z\d])([A-Z])/,'\1_\2').
+          tr("-", "_").
+          downcase
+      end
     end
 
     def [](service_key)
@@ -46,16 +58,6 @@ module Fog
         )
       )
       ['Fog', constant_string, provider].join("::")
-    end
-
-    private
-
-    def underscore_name(string)
-      string.gsub(/::/, '/').
-        gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-        gsub(/([a-z\d])([A-Z])/,'\1_\2').
-        tr("-", "_").
-        downcase
     end
   end
 end


### PR DESCRIPTION
This method was defined on the instance level, not the class level, so `Provider.extends` couldn't get to it. Broke our build when we attempted to update to v2.2.1.