### PR TITLE
add fog-specific debug var

### DIFF
--- a/lib/fog/core/logger.rb
+++ b/lib/fog/core/logger.rb
@@ -6,6 +6,10 @@ module Fog
     }
 
     @channels[:debug] = ::STDERR if ENV["DEBUG"]
+    # We cannot necessarily set the DEBUG environment variable for fog-azure-rm because
+    # that would log the complete HTTP body since this variable is also used by the Azure storage SDK.
+    # Instead let's offer another way to enable fog-azure-rm debug logging
+    @channels[:debug] = ::STDERR if ENV["FOG_DEBUG"]
 
     def self.[](channel)
       @channels[channel]


### PR DESCRIPTION
We need to enable DEBUG logging for fog-azure-rm but we cannot necessarily set the DEBUG environment variable for fog-azure-rm because that would log the complete HTTP body because of https://github.com/fog/fog-azure-rm/blob/9da5cc04189cd1ec751c5bc1e2f5406ce6b179d0/lib/fog/azurerm/storage.rb#L96-L97.
Proposal is to instead offer another env variable 'FOG_DEBUG' to enable only logging on fog-azure-rm level.
Similar change was proposed here: https://github.com/fog/fog-azure-rm/pull/431
But there it is done for branch fog-arm-cf only...