### PR TITLE
PERF: Eliminate dependency on mime-types gem

### DIFF
--- a/fog-core.gemspec
+++ b/fog-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency("builder")
-  spec.add_dependency("mime-types")
+  spec.add_dependency('mini_mime', '>= 0.1.1')
   spec.add_dependency("excon", "~> 0.71")
   spec.add_dependency("formatador", "~> 0.2")
 

--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -1,9 +1,4 @@
-begin
-  # Use mime/types/columnar if available, for reduced memory usage
-  require 'mime/types/columnar'
-rescue LoadError
-  require 'mime/types'
-end
+require 'mini_mime'
 
 module Fog
   module Storage
@@ -47,9 +42,8 @@ module Fog
     def self.get_content_type(data)
       if data.respond_to?(:path) && !data.path.nil?
         filename = ::File.basename(data.path)
-        unless (mime_types = MIME::Types.of(filename)).empty?
-          mime_types.first.content_type
-        end
+        mime = MiniMime.lookup_by_filename(filename)
+        mime ? mime.content_type : 'text/plain'
       end
     end
 


### PR DESCRIPTION
**Inspired by: https://github.com/rest-client/rest-client/pull/644**

Eliminate the dependency on `mime-types` which is a memory hog.

The gem `mini_mime` (https://github.com/discourse/mini_mime) was created in replacement. It uses the exact same database as the full fledged mime types and is capable of only loading stuff on demand with a practical, safe and bound in-memory cache.

Allocated memory by gem (derailed benchmarks):

| gem | memory |
|---|---|
| mime-types | 6258796 | 
| mini_mime | 7606 |
