### PR TITLE
Fix formatting of v2.2.4 changelog items

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,9 @@
 2.2.4 04/28/2020
 ==========================================================
 
-Add FOG_DEBUG in addition to DEBUG to allow avoiding namespace collisions
-Add github actions configuration
-Update succeeds helper to expected syntax for ruby 3+
+- Add FOG_DEBUG in addition to DEBUG to allow avoiding namespace collisions
+- Add github actions configuration
+- Update succeeds helper to expected syntax for ruby 3+
 
 2.2.3 09/16/2020
 ==========================================================


### PR DESCRIPTION
Otherwise the markdown squashes all the items to same line