### PR TITLE
Avoid loading unnecessary service via autoload

### DIFF
--- a/lib/fog/core/provider.rb
+++ b/lib/fog/core/provider.rb
@@ -45,19 +45,20 @@ module Fog
     # "provider::service" is defined (the preferred format) then it returns that
     # string, otherwise it returns the deprecated string "service::provider".
     def service_klass(constant_string)
-      eval([to_s, constant_string].join("::"))
-      [to_s, constant_string].join("::")
-    rescue NameError
-      provider = to_s.split("::").last
-      Fog::Logger.deprecation("Unable to load #{[to_s, constant_string].join("::")}")
-      Fog::Logger.deprecation(
-        format(
-          Fog::ServicesMixin::E_SERVICE_PROVIDER_CONSTANT,
-          service: constant_string,
-          provider: provider
+      if const_defined?([to_s, constant_string].join("::"))
+        [to_s, constant_string].join("::")
+      else
+        provider = to_s.split("::").last
+        Fog::Logger.deprecation("Unable to load #{[to_s, constant_string].join("::")}")
+        Fog::Logger.deprecation(
+          format(
+            Fog::ServicesMixin::E_SERVICE_PROVIDER_CONSTANT,
+            service: constant_string,
+            provider: provider
+          )
         )
-      )
-      ['Fog', constant_string, provider].join("::")
+        ['Fog', constant_string, provider].join("::")
+      end
     end
   end
 end

--- a/spec/compute_spec.rb
+++ b/spec/compute_spec.rb
@@ -10,29 +10,22 @@ describe "Fog::Compute" do
   describe "#new" do
     module Fog
       module TheRightWay
-        extend Provider
-        service(:compute, "Compute")
-      end
-    end
-
-    module Fog
-      module TheRightWay
         class Compute
           def initialize(_args); end
         end
       end
     end
 
-    it "instantiates an instance of Fog::Compute::<Provider> from the :provider keyword arg" do
-      compute = Fog::Compute.new(:provider => :therightway)
-      assert_instance_of(Fog::TheRightWay::Compute, compute)
-    end
-
     module Fog
-      module TheWrongWay
+      module TheRightWay
         extend Provider
         service(:compute, "Compute")
       end
+    end
+
+    it "instantiates an instance of Fog::Compute::<Provider> from the :provider keyword arg" do
+      compute = Fog::Compute.new(:provider => :therightway)
+      assert_instance_of(Fog::TheRightWay::Compute, compute)
     end
 
     module Fog
@@ -43,16 +36,16 @@ describe "Fog::Compute" do
       end
     end
 
-    it "instantiates an instance of Fog::<Provider>::Compute from the :provider keyword arg" do
-      compute = Fog::Compute.new(:provider => :thewrongway)
-      assert_instance_of(Fog::Compute::TheWrongWay, compute)
-    end
-
     module Fog
-      module BothWays
+      module TheWrongWay
         extend Provider
         service(:compute, "Compute")
       end
+    end
+
+    it "instantiates an instance of Fog::<Provider>::Compute from the :provider keyword arg" do
+      compute = Fog::Compute.new(:provider => :thewrongway)
+      assert_instance_of(Fog::Compute::TheWrongWay, compute)
     end
 
     module Fog
@@ -71,6 +64,13 @@ describe "Fog::Compute" do
         class BothWays
           def initialize(_args); end
         end
+      end
+    end
+
+    module Fog
+      module BothWays
+        extend Provider
+        service(:compute, "Compute")
       end
     end
 

--- a/spec/identity_spec.rb
+++ b/spec/identity_spec.rb
@@ -10,29 +10,22 @@ describe "Fog::Identity" do
   describe "#new" do
     module Fog
       module TheRightWay
-        extend Provider
-        service(:identity, "Identity")
-      end
-    end
-
-    module Fog
-      module TheRightWay
         class Identity
           def initialize(_args); end
         end
       end
     end
 
-    it "instantiates an instance of Fog::Identity::<Provider> from the :provider keyword arg" do
-      identity = Fog::Identity.new(:provider => :therightway)
-      assert_instance_of(Fog::TheRightWay::Identity, identity)
-    end
-
     module Fog
-      module TheWrongWay
+      module TheRightWay
         extend Provider
         service(:identity, "Identity")
       end
+    end
+
+    it "instantiates an instance of Fog::Identity::<Provider> from the :provider keyword arg" do
+      identity = Fog::Identity.new(:provider => :therightway)
+      assert_instance_of(Fog::TheRightWay::Identity, identity)
     end
 
     module Fog
@@ -43,16 +36,16 @@ describe "Fog::Identity" do
       end
     end
 
-    it "instantiates an instance of Fog::<Provider>::Identity from the :provider keyword arg" do
-      identity = Fog::Identity.new(:provider => :thewrongway)
-      assert_instance_of(Fog::Identity::TheWrongWay, identity)
-    end
-
     module Fog
-      module BothWays
+      module TheWrongWay
         extend Provider
         service(:identity, "Identity")
       end
+    end
+
+    it "instantiates an instance of Fog::<Provider>::Identity from the :provider keyword arg" do
+      identity = Fog::Identity.new(:provider => :thewrongway)
+      assert_instance_of(Fog::Identity::TheWrongWay, identity)
     end
 
     module Fog
@@ -71,6 +64,13 @@ describe "Fog::Identity" do
         class BothWays
           def initialize(_args); end
         end
+      end
+    end
+
+    module Fog
+      module BothWays
+        extend Provider
+        service(:identity, "Identity")
       end
     end
 

--- a/spec/storage_spec.rb
+++ b/spec/storage_spec.rb
@@ -10,16 +10,16 @@ describe "Fog::Storage" do
   describe "#new" do
     module Fog
       module TheRightWay
-        extend Provider
-        service(:storage, "Storage")
+        class Storage
+          def initialize(_args); end
+        end
       end
     end
 
     module Fog
       module TheRightWay
-        class Storage
-          def initialize(_args); end
-        end
+        extend Provider
+        service(:storage, "Storage")
       end
     end
 
@@ -29,28 +29,21 @@ describe "Fog::Storage" do
     end
 
     module Fog
-      module TheWrongWay
-        extend Provider
-        service(:storage, "Storage")
-      end
-
       module Storage
         class TheWrongWay
           def initialize(_args); end
         end
+      end
+
+      module TheWrongWay
+        extend Provider
+        service(:storage, "Storage")
       end
     end
 
     it "instantiates an instance of Fog::Storage::<Provider> from the :provider keyword arg" do
       compute = Fog::Storage.new(:provider => :thewrongway)
       assert_instance_of(Fog::Storage::TheWrongWay, compute)
-    end
-
-    module Fog
-      module BothWays
-        extend Provider
-        service(:storage, "Storage")
-      end
     end
 
     module Fog
@@ -70,6 +63,13 @@ describe "Fog::Storage" do
         class BothWays
           def initialize(_args); end
         end
+      end
+    end
+
+    module Fog
+      module BothWays
+        extend Provider
+        service(:storage, "Storage")
       end
     end
 


### PR DESCRIPTION
This change avoids loading unnecessary service classes when the service is defined with `autoload`, such as fog-aws.


# Problem


fog-aws  uses `autoload` to load each service to avoid loading unnecessary service. By the `autoload`s, the end-users can reduce startup time and memory usage.
But the `autoload`s don't work actually. fog-aws loads all services even if the user doesn't need all services.



Because fog-core evaluates all services' constants with `eval` method. The evaluation loads unnecessary code unexpectedly.



# Solution


Use `const_efined?` instead of `eval`. `const_defined?` method checks constant existence without loading the code.


Note that I also reorder class definitions in the test. It reduces unexpected warnings, such as `Unable to load ...`. It doesn't the test result, so I'll revert the test changes if you don't need it.


# Benchmark

I benchmarked memory usage and startup time with `fog-aws` package.

## memory usage


It reduces about 585KB, 9%.

### before

```bash
$ RUBYLIB=lib ruby -robjspace -e 'require "fog/aws";GC.start; puts "#{ObjectSpace.memsize_of_all * 0.001 * 0.001} MB"'
6.844114 MB
```

### after


```bash
$ RUBYLIB=lib ruby -robjspace -e 'require "fog/aws";GC.start; puts "#{ObjectSpace.memsize_of_all * 0.001 * 0.001} MB"'
6.258867 MB
```

## Startup time

It reduces about 45ms, 9%.

### before

```bash
$ RUBYLIB=lib ruby -robjspace -rbenchmark -e 'p(Benchmark.realtime {require "fog/aws"})'
0.5202090488746762
```

### after

```bash
$ RUBYLIB=lib ruby -robjspace -rbenchmark -e 'p(Benchmark.realtime {require "fog/aws"})'
0.47530297795310616
```