### PR TITLE
Add Truffleruby head to CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', 'head']
+        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', 'truffleruby-head', 'head']
 
     steps:
     - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
Hi, I notice that MRI Ruby head is failing here, but Truffleruby head passes