### PR TITLE
Cache and restore collection attributes

### DIFF
--- a/spec/compute/models/server_spec.rb
+++ b/spec/compute/models/server_spec.rb
@@ -55,7 +55,7 @@ describe Fog::Compute::Server do
           it "is false" do
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raise_error = lambda { |_cmd, _options| raise Net::SSH::AuthenticationFailed.new }
+                raise_error = lambda { |_cmd, _options={}| raise Net::SSH::AuthenticationFailed.new }
                 @server.stub(:ssh, raise_error) do
                   refute @server.sshable?
                 end
@@ -67,7 +67,7 @@ describe Fog::Compute::Server do
             @server.instance_variable_set(:@sshable_timeout, 8)
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raise_error = lambda { |_cmd, _options| raise Net::SSH::AuthenticationFailed.new }
+                raise_error = lambda { |_cmd, _options={}| raise Net::SSH::AuthenticationFailed.new }
                 @server.stub(:ssh, raise_error) do
                   @server.sshable?
                   assert_nil @server.instance_variable_get(:@sshable_timeout), nil
@@ -81,7 +81,7 @@ describe Fog::Compute::Server do
           it "is false" do
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raise_error = lambda { |_cmd, _options| raise Net::SSH::Disconnect.new }
+                raise_error = lambda { |_cmd, _options={}| raise Net::SSH::Disconnect.new }
                 @server.stub(:ssh, raise_error) do
                   refute @server.sshable?
                 end
@@ -93,7 +93,7 @@ describe Fog::Compute::Server do
             @server.instance_variable_set(:@sshable_timeout, 8)
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raise_error = lambda { |_cmd, _options| raise Net::SSH::Disconnect.new }
+                raise_error = lambda { |_cmd, _options={}| raise Net::SSH::Disconnect.new }
                 @server.stub(:ssh, raise_error) do
                   @server.sshable?
                   assert_nil @server.instance_variable_get(:@sshable_timeout), nil
@@ -107,7 +107,7 @@ describe Fog::Compute::Server do
           it "is false" do
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raise_error = lambda { |_cmd, _options| raise SystemCallError.new("message, 0") }
+                raise_error = lambda { |_cmd, _options={}| raise SystemCallError.new("message, 0") }
                 @server.stub(:ssh, raise_error) do
                   refute @server.sshable?
                 end
@@ -118,7 +118,7 @@ describe Fog::Compute::Server do
           it "does not increase SSH timeout" do
             @server.stub(:ready?, true) do
               @server.stub(:ssh_ip_address, "10.0.0.1") do
-                raise_error = lambda { |_cmd, _options| raise SystemCallError.new("message, 0") }
+                raise_error = lambda { |_cmd, _options={}| raise SystemCallError.new("message, 0") }
                 @server.stub(:ssh, raise_error) do
                   @server.sshable?
                   assert_equal @server.instance_variable_get(:@sshable_timeout), 8

--- a/spec/core/cache_spec.rb
+++ b/spec/core/cache_spec.rb
@@ -9,6 +9,14 @@ module Fog
 end
 
 module Fog
+  class SubFogTestCollection < Fog::Collection
+    model Fog::SubFogTestModel
+
+    attribute :spec_attribute
+  end
+end
+
+module Fog
   class SubFogTestService < Fog::Service
 
     class Mock
@@ -187,5 +195,20 @@ describe Fog::Cache do
 
     # unique-ify based on the attributes...
     assert_equal instances.size, 2
+  end
+
+  it "dumps model with collection attributes and reloads them" do
+    Fog::Cache.expire_cache!(Fog::SubFogTestModel, @service)
+
+    c = Fog::SubFogTestCollection.new(:service => @service, :spec_attribute => 42)
+
+    id = SecureRandom.hex
+    a = Fog::SubFogTestModel.new(:id => id, :service => @service, :collection => c)
+
+    a.cache.dump
+
+    instances = Fog::Cache.load(Fog::SubFogTestModel, @service)
+    assert_equal instances.first.id, id
+    assert_equal instances.first.collection.spec_attribute, 42
   end
 end


### PR DESCRIPTION
Some collections also have attributes. It is better to cache collection's attributes too and properly restore model and collection.

For example, DNS `Zone` model has `Records` collection. This collection requires `zone_id` attribute to operate: get all records by `zone_id`, get record by `zone_id` and record `identity`, etc. When we load from cache a `Record` Fog creates collection for this model without any attributes.

Also when cache is not `valid_for_load?` let display which keys are missing.