### PR TITLE
Model methods

### DIFF
--- a/lib/fog/core/model.rb
+++ b/lib/fog/core/model.rb
@@ -21,6 +21,33 @@ module Fog
       merge_attributes(attribs)
     end
 
+    # Creates new or updates existing model
+    # @return [self]
+    def save
+      persisted? ? update : create
+    end
+
+    # Creates new entity from model
+    # @raise [Fog::Errors::NotImplemented] you must implement #create method in child class and return self
+    # @return [self]
+    def create
+      raise Fog::Errors::NotImplemented, "Implement method #create for #{self.class}. Method must return self"
+    end
+
+    # Updates new entity with model
+    # @raise [Fog::Errors::NotImplemented] you must implement #update method in child class and return self
+    # @return [self]
+    def update
+      raise Fog::Errors::NotImplemented, "Implement method #update for #{self.class}. Method must return self"
+    end
+
+    # Destroys entity by model identity
+    # @raise [Fog::Errors::NotImplemented] you must implement #destroy method in child class and return self
+    # @return [self]
+    def destroy
+      raise Fog::Errors::NotImplemented, "Implement method #destroy for #{self.class}. Method must return self"
+    end
+
     def cache
       Fog::Cache.new(self)
     end
@@ -41,6 +68,8 @@ module Fog
       end
     end
 
+    # @return [self] if model successfully reloaded
+    # @return [nil] if something went wrong or model was not found
     def reload
       requires :identity
 

--- a/spec/core/model_spec.rb
+++ b/spec/core/model_spec.rb
@@ -3,6 +3,17 @@ require "securerandom"
 
 class FogTestModel < Fog::Model
   identity  :id
+  attribute :value
+
+  def create
+    self.identity = SecureRandom.hex
+    self
+  end
+
+  def update
+    self.value = 42
+    self
+  end
 end
 
 describe Fog::Model do
@@ -31,6 +42,28 @@ describe Fog::Model do
     it "is not equal if it has a different identity" do
       refute_equal FogTestModel.new(:id => SecureRandom.hex),
                    FogTestModel.new(:id => SecureRandom.hex)
+    end
+  end
+
+  describe "#save" do
+    describe "on a non persisted object" do
+      it "creates a new resource" do
+        a = FogTestModel.new
+        a.stub(:persisted?, false) do
+          a.save
+          refute_nil(a.identity)
+        end
+      end
+    end
+
+    describe "on a persisted object" do
+      it "updates resource" do
+        a = FogTestModel.new
+        a.stub(:persisted?, true) do
+          a.save
+          assert_equal(a.value, 42)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Please, do not squash commits when (if) merging.

Add methods `#create`, `#update`, `#save`, `#destroy` explicitly.
Be more consistent with return values.
Add `filter_attributes` helper method.

Commit messages below:

---
Model methods like #save or #destroy are implicit: they only mentioned
in README but explicitly used by framework. Let define them also
explicitly so developer knows exactly what to implement.

This change is not breaking change, because either method is already
defined in child class or is not used at all.

Another goal is to make return values consistent.

---
It is just handy method to easily get a sub-set of attributes.
For example, my model has 10+ attributes, but when creating/updating
model I need only a few of them:

Code:
    ...
    attribute :name
    attribute :value
    attribute :comment
    attribute :type
    ...
    service.create_entity(filter_attributes(:name, :value, :type))