### PR TITLE
Add filter_attributes method

### DIFF
--- a/lib/fog/core/attributes.rb
+++ b/lib/fog/core/attributes.rb
@@ -25,6 +25,14 @@ module Fog
         @masks ||= {}
       end
 
+      # Defines a new attribute
+      # @param [Symbol] name attribute name
+      # @param [Hash] options (see {Default#initialize})
+      # @option options [Symbol, ::String] :type attribute type (see {Attributes})
+      # @option options [Symbol] :squash
+      # @option options [::Array] :aliases
+      # @option options [Object] :default
+      # @option options [Object] :as
       def attribute(name, options = {})
         type = options.fetch(:type, "default").to_s.capitalize
         Fog::Attributes.const_get(type).new(self, name, options)
@@ -125,6 +133,9 @@ module Fog
         send("#{identity_name}=", new_identity)
       end
 
+      # Merges attributes into self
+      # @note Ignored attributes are not merged (see {ClassMethods.ignored_attributes})
+      # @return [self]
       def merge_attributes(new_attributes = {})
         new_attributes.each_pair do |key, value|
           next if self.class.ignored_attributes.include?(key)
@@ -137,6 +148,18 @@ module Fog
           end
         end
         self
+      end
+
+      # Filters attributes by selected attribute names
+      # @note In some cases we want to easily get subset of model attributes
+      # @note Hash#slice requires Ruby >= 2.5.0
+      # @param [Symbol] selected attribute names
+      # @return [Hash] new hash with selected attributes
+      def filter_attributes(*selected)
+        filtered = attributes.select { |a, _| selected.include?(a) }
+
+        # we should use getters instead of direct accessing attributes hash
+        filtered.each_key { |k| filtered[k] = send(k) }
       end
 
       # Returns true if a remote resource has been assigned an

--- a/lib/fog/core/attributes/default.rb
+++ b/lib/fog/core/attributes/default.rb
@@ -7,6 +7,13 @@ module Fog
     class Default
       attr_reader :model, :name, :squash, :aliases, :default, :as
 
+      # @param [Klass] model model class
+      # @param [Symbol] name name of the attribute
+      # @param [Hash] options attribute options
+      # @option options [Symbol] :squash
+      # @option options [::Array] :aliases
+      # @option options [Object] :default
+      # @option options [Object] :as
       def initialize(model, name, options)
         @model = model
         @model.attributes << name

--- a/spec/fog_attribute_spec.rb
+++ b/spec/fog_attribute_spec.rb
@@ -47,6 +47,7 @@ class FogAttributeTestModel < Fog::Model
   attribute :default, :default => "default_value", :aliases => :some_name
   attribute :another_default, :default => false
   attribute :good_name, :as => :Badname
+  attribute :custom_getter, :type => :integer
 
   has_one :one_object, :single_associations, :aliases => :single
   has_many :many_objects, :multiple_associations
@@ -65,6 +66,10 @@ class FogAttributeTestModel < Fog::Model
 
   def requires_test
     requires :string, :integer
+  end
+
+  def custom_getter
+    (attributes[:custom_getter] || 0) + 10
   end
 end
 
@@ -435,7 +440,8 @@ describe "Fog::Attributes" do
                                              :array => [],
                                              :default => nil,
                                              :another_default => nil,
-                                             :Badname => nil
+                                             :Badname => nil,
+                                             :custom_getter => 10
       end
     end
 
@@ -454,7 +460,8 @@ describe "Fog::Attributes" do
                                              :array => [],
                                              :default => "default_value",
                                              :another_default => false,
-                                             :Badname => nil
+                                             :Badname => nil,
+                                             :custom_getter => 10
       end
     end
   end
@@ -508,6 +515,7 @@ describe "Fog::Attributes" do
                                                              :default => nil,
                                                              :another_default => nil,
                                                              :Badname => nil,
+                                                             :custom_getter => 10,
                                                              :one_object => @one_object,
                                                              :many_objects => @many_objects,
                                                              :objects => [],
@@ -537,6 +545,7 @@ describe "Fog::Attributes" do
                                                              :default => "default_value",
                                                              :another_default => false,
                                                              :Badname => nil,
+                                                             :custom_getter => 10,
                                                              :one_object => @one_object,
                                                              :many_objects => @many_objects,
                                                              :objects => [],
@@ -544,6 +553,17 @@ describe "Fog::Attributes" do
                                                              :Crazyname => "XYZ",
                                                              :many_identities => %w(ABC)
       end
+    end
+  end
+
+  describe "#filter_attributes" do
+    it "should return filtered attributes using model getters" do
+      model.merge_attributes(:id => 2, :float => 3.2, :integer => 55_555_555, :bool => nil, :custom_getter => 66)
+      filtered = model.filter_attributes(:id, :float, :bool, :custom_getter)
+      assert_equal filtered, :id => 2,
+                             :float => 3.2,
+                             :bool => nil,
+                             :custom_getter => 76
     end
   end
 end


### PR DESCRIPTION
It is just handy method to easily get a sub-set of attributes. For example, my model has 10+ attributes, but when creating/updating model I need only a few of them:

Code:
    ...
    attribute :name
    attribute :value
    attribute :comment
    attribute :type
    ...
    service.create_entity(filter_attributes(:name, :value, :type))