### PR TITLE
Cache load

### DIFF
--- a/lib/fog/core/cache.rb
+++ b/lib/fog/core/cache.rb
@@ -205,12 +205,22 @@ module Fog
       FileUtils.rm_rf(SANDBOX)
     end
 
+    # Load YAML file with aliases
+    # @note Starting from Ruby 3.1 we must explicitly tell Psych to allow aliases
+    def self.yaml_load(path)
+      if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1.0")
+        YAML.load(path, aliases: true)
+      else
+        YAML.load(path)
+      end
+    end
+
     # loads yml cache from path on disk, used
     # to initialize Fog models.
     def self.load_cache(path)
       @memoized ||= {}
       return @memoized[path] if @memoized[path]
-      @memoized[path] = YAML.load(File.read(path))
+      @memoized[path] = yaml_load(File.read(path))
     end
 
     def self.namespace_prefix=(name)
@@ -234,7 +244,7 @@ module Fog
 
       mpath = File.join(SANDBOX, namespace_prefix, "metadata.yml")
       to_write = if File.exist?(mpath)
-                YAML.dump(YAML.load(File.read(mpath)).merge!(h))
+                YAML.dump(yaml_load(File.read(mpath)).merge!(h))
               else
                 YAML.dump(h)
               end
@@ -249,7 +259,7 @@ module Fog
     def self.metadata
       mpath = File.join(SANDBOX, namespace_prefix, "metadata.yml")
       if File.exist?(mpath)
-        metadata = YAML.load(File.read(mpath))
+        metadata = yaml_load(File.read(mpath))
         return metadata
       else
         return {}

--- a/spec/core/cache_spec.rb
+++ b/spec/core/cache_spec.rb
@@ -5,6 +5,22 @@ require "tmpdir"
 module Fog
   class SubFogTestModel < Fog::Model
     identity  :id
+
+    attribute :config
+    attribute :subconfig
+
+    def initialize(new_attributes = {})
+      super
+
+      # This way we make YAML to use aliases
+      self.config = {
+        "users" => [
+          { "user1" => "user1@email" },
+          { "user2" => "user2@email" }
+        ]
+      }
+      self.subconfig = config['users'][0]
+    end
   end
 end
 
@@ -75,8 +91,7 @@ describe Fog::Cache do
       Fog::Cache.namespace_prefix = nil
       Fog::Cache.write_metadata({:a => "b"})
     end
-
- end
+  end
 
   it "can load cache data from disk" do
     path = File.expand_path("~/.fog-cache-test-#{Time.now.to_i}.yml")

--- a/spec/core/cache_spec.rb
+++ b/spec/core/cache_spec.rb
@@ -1,6 +1,5 @@
 require "spec_helper"
 require "securerandom"
-require "tmpdir"
 
 module Fog
   class SubFogTestModel < Fog::Model

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,10 @@ if ENV["COVERAGE"]
   end
 end
 
+# Set home outside of real user
+require 'tmpdir'
+ENV["HOME"] = Dir.mktmpdir('foghome')
+
 require "minitest/autorun"
 require "minitest/spec"
 require "minitest/stub_const"


### PR DESCRIPTION
Two commits, no need to squash.

Fixes cache load with aliases/anchors.
Uses temporary directory for cache tests.