### PR TITLE
Fix compatibility with Minitest 5.19+

### DIFF
--- a/lib/fog/test_helpers/minitest/assertions.rb
+++ b/lib/fog/test_helpers/minitest/assertions.rb
@@ -1,6 +1,6 @@
 require "fog/schema/data_validator"
 
-module MiniTest::Assertions
+module Minitest::Assertions
   # Compares a hash's structure against a reference schema hash and returns true
   # when they match. Fog::Schema::Datavalidator is used for the validation.
   def assert_match_schema(actual, schema, message = nil, options = {})

--- a/lib/fog/test_helpers/minitest/expectations.rb
+++ b/lib/fog/test_helpers/minitest/expectations.rb
@@ -1,3 +1,3 @@
-module MiniTest::Expectations
+module Minitest::Expectations
   infect_an_assertion :assert_match_schema, :must_match_schema, :reverse
 end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -172,7 +172,7 @@ describe Fog::Service do
 
   describe "when config object can configure the service itself" do
     it "ignores the global and its values" do
-      @config = MiniTest::Mock.new
+      @config = Minitest::Mock.new
       def @config.config_service?;  true; end
       def @config.nil?; false; end
       def @config.==(other); object_id == other.object_id; end


### PR DESCRIPTION
The `MiniTest` was renamed to `Minitest`:

https://github.com/minitest/minitest/commit/9a57c520ceac76abfe6105866f8548a94eb357b6

And the `MiniTest` constant is now loaded just when `MT_COMPAT` environment variable is set:

https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6