### PR TITLE
Reapply "Delegate methods that accept keywords from Fog::Collection t…

### DIFF
--- a/lib/fog/core/collection.rb
+++ b/lib/fog/core/collection.rb
@@ -19,6 +19,7 @@ module Fog
           end
           super
         end
+        ruby2_keywords(method) if respond_to?(:ruby2_keywords, true)
       EOS
     end
 
@@ -31,6 +32,7 @@ module Fog
           data = super
           self.clone.clear.concat(data)
         end
+        ruby2_keywords(method) if respond_to?(:ruby2_keywords, true)
       EOS
     end
 

--- a/spec/core/collection_spec.rb
+++ b/spec/core/collection_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+require "securerandom"
+
+class FogTestModelForCollection < Fog::Model
+  identity  :id
+end
+
+class FogTestCollection < Fog::Collection
+  model FogTestModelForCollection
+
+  def all
+    self
+  end
+end
+
+describe Fog::Collection do
+  describe "array delegation" do
+    it "delegates methods with keywords to Array" do
+      c = FogTestCollection.new
+      c << FogTestModelForCollection.new(id: SecureRandom.hex)
+      assert_equal c.sample(1, random: Random)[0], c[0]
+    end
+  end
+end


### PR DESCRIPTION
…o Array correctly for Ruby 2.x and Ruby 3.x (#292)" (#295)

This reverts commit 917bcb73f5a6c1c0f29fbf510345c5d8e4a1f490.