### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/fog-core

### DIFF
--- a/fog-core.gemspec
+++ b/fog-core.gemspec
@@ -39,5 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("tins")
   spec.add_development_dependency("yard")
 
+  spec.metadata["changelog_uri"] = spec.homepage + "/blob/master/changelog.md"
   spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/fog-core which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/